### PR TITLE
Add canonical URL for Bandera Azul course page

### DIFF
--- a/Cursos/bandera-azul.html
+++ b/Cursos/bandera-azul.html
@@ -11,7 +11,8 @@
   <meta property="og:url" content="https://garuas.com/Cursos/bandera-azul.html" />
   <meta property="og:image" content="https://garuas.com/assets/garua_logo_banner2_recortado.png" />
   <meta property="og:locale" content="es_CR" />
-  <link rel="alternate" hreflang="es-CR" href="https://garuas.com/cursos/bandera-azul.html" />
+  <link rel="canonical" href="https://garuas.com/Cursos/bandera-azul.html" />
+  <link rel="alternate" hreflang="es-CR" href="https://garuas.com/Cursos/bandera-azul.html" />
   <link rel="icon" href="/assets/logo.png" />
   <script src="https://cdn.tailwindcss.com"></script>
   <style>html{scroll-behavior:smooth}</style>


### PR DESCRIPTION
## Summary
- Add canonical URL to Bandera Azul course page
- Update alternate link to match canonical path

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7f80155e4832e8b52233bdf71a35c