### PR TITLE
Add labels and IDs to form fields

### DIFF
--- a/Cursos/bandera-azul.html
+++ b/Cursos/bandera-azul.html
@@ -113,20 +113,20 @@
         <form action="https://formspree.io/f/xpwlbowj" method="POST" class="mt-6 space-y-4 rounded-2xl border bg-white p-6 shadow-sm">
           <input type="hidden" name="_subject" value="Registro webinar Bandera Azul · Garúa" />
           <div>
-            <label class="block text-sm font-medium">Nombre y apellidos</label>
-            <input required name="nombre" class="mt-1 w-full rounded-lg border px-3 py-2" placeholder="Nombre completo" />
+            <label for="nombre" class="block text-sm font-medium">Nombre y apellidos</label>
+            <input id="nombre" required name="nombre" class="mt-1 w-full rounded-lg border px-3 py-2" placeholder="Nombre completo" />
           </div>
           <div>
-            <label class="block text-sm font-medium">Correo electrónico</label>
-            <input required type="email" name="email" class="mt-1 w-full rounded-lg border px-3 py-2" placeholder="correo@empresa.com" />
+            <label for="email" class="block text-sm font-medium">Correo electrónico</label>
+            <input id="email" required type="email" name="email" class="mt-1 w-full rounded-lg border px-3 py-2" placeholder="correo@empresa.com" />
           </div>
           <div>
-            <label class="block text-sm font-medium">Empresa</label>
-            <input name="empresa" class="mt-1 w-full rounded-lg border px-3 py-2" placeholder="Nombre de la empresa (opcional)" />
+            <label for="empresa" class="block text-sm font-medium">Empresa</label>
+            <input id="empresa" name="empresa" class="mt-1 w-full rounded-lg border px-3 py-2" placeholder="Nombre de la empresa (opcional)" />
           </div>
           <div>
-            <label class="block text-sm font-medium">Sector</label>
-            <select name="sector" class="mt-1 w-full rounded-lg border px-3 py-2">
+            <label for="sector" class="block text-sm font-medium">Sector</label>
+            <select id="sector" name="sector" class="mt-1 w-full rounded-lg border px-3 py-2">
               <option>Industrial</option>
               <option>Servicios</option>
               <option>Turismo/Hotelero</option>

--- a/index.html
+++ b/index.html
@@ -224,10 +224,14 @@
 
     <form action="https://formspree.io/f/mwpqavdr" method="POST" class="rounded-2xl border p-6 bg-white max-w-4xl mx-auto">
       <div class="grid grid-cols-1 gap-4">
-        <input class="rounded-xl border p-3" name="name" placeholder="Nombre" required />
-        <input class="rounded-xl border p-3" name="email" placeholder="Correo" type="email" required />
-        <input class="rounded-xl border p-3" name="phone" placeholder="Teléfono / WhatsApp" />
-        <textarea class="rounded-xl border p-3 min-h-[120px]" name="message" placeholder="¿En qué podemos ayudarte?" required></textarea>
+        <label for="name" class="sr-only">Nombre</label>
+        <input id="name" class="rounded-xl border p-3" name="name" placeholder="Nombre" required />
+        <label for="email" class="sr-only">Correo</label>
+        <input id="email" class="rounded-xl border p-3" name="email" placeholder="Correo" type="email" required />
+        <label for="phone" class="sr-only">Teléfono / WhatsApp</label>
+        <input id="phone" class="rounded-xl border p-3" name="phone" placeholder="Teléfono / WhatsApp" />
+        <label for="message" class="sr-only">¿En qué podemos ayudarte?</label>
+        <textarea id="message" class="rounded-xl border p-3 min-h-[120px]" name="message" placeholder="¿En qué podemos ayudarte?" required></textarea>
         <input type="hidden" name="_subject" value="Nuevo contacto desde garuas.com">
         <input type="text" name="_gotcha" class="hidden" tabindex="-1" autocomplete="off">
         <button class="rounded-2xl bg-teal-700 px-5 py-3 text-white font-semibold w-max" type="submit">Enviar</button>


### PR DESCRIPTION
## Summary
- add hidden labels and id attributes to contact form inputs for screen reader support
- link registration form labels to their corresponding inputs via matching ids

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a7f8041318832e92a389a4ed842e68