### PR TITLE
Link consultoria and Bandera Azul pages

### DIFF
--- a/Cursos/bandera-azul/index.html
+++ b/Cursos/bandera-azul/index.html
@@ -8,11 +8,11 @@
   <meta property="og:title" content="Webinar Gratis · Bandera Azul Ecológica para su empresa" />
   <meta property="og:description" content="Requisitos y pasos clave para empresas privadas en Costa Rica. Regístrese gratis." />
   <meta property="og:type" content="event" />
-  <meta property="og:url" content="https://garuas.com/Cursos/bandera-azul.html" />
+  <meta property="og:url" content="https://garuas.com/Cursos/bandera-azul/" />
   <meta property="og:image" content="https://garuas.com/assets/garua_logo_banner2_recortado.png" />
   <meta property="og:locale" content="es_CR" />
-  <link rel="canonical" href="https://garuas.com/Cursos/bandera-azul.html" />
-  <link rel="alternate" hreflang="es-CR" href="https://garuas.com/Cursos/bandera-azul.html" />
+  <link rel="canonical" href="https://garuas.com/Cursos/bandera-azul/" />
+  <link rel="alternate" hreflang="es-CR" href="https://garuas.com/Cursos/bandera-azul/" />
   <link rel="icon" href="/assets/logo.png" />
   <script src="https://cdn.tailwindcss.com"></script>
   <style>html{scroll-behavior:smooth}</style>

--- a/Cursos/index.html
+++ b/Cursos/index.html
@@ -39,7 +39,7 @@
       <article class="rounded-xl border p-6 bg-white">
         <h2 class="text-xl font-semibold">Webinar: Bandera Azul Ecológica para su empresa</h2>
         <p class="mt-2 text-slate-700">Requisitos y pasos clave para empresas privadas en Costa Rica.</p>
-        <a href="/Cursos/bandera-azul.html" class="mt-4 inline-flex items-center text-sky-700 hover:underline">Ver detalles →</a>
+        <a href="/Cursos/bandera-azul/" class="mt-4 inline-flex items-center text-sky-700 hover:underline">Ver detalles →</a>
       </article>
 
       <article class="rounded-xl border p-6 bg-white">

--- a/index.html
+++ b/index.html
@@ -82,6 +82,8 @@
     <nav class="hidden md:flex items-center gap-6 text-sm">
       <a href="#servicios" class="hover:text-teal-700">Servicios</a>
       <a href="#sectores" class="hover:text-teal-700">Sectores</a>
+      <a href="/consultoria-ambiental-costa-rica/" class="hover:text-teal-700">Consultoría</a>
+      <a href="/Cursos/bandera-azul/" class="hover:text-teal-700">Bandera Azul</a>
       <a href="#nosotros" class="hover:text-teal-700">Nosotros</a>
       <a href="#contacto" class="inline-flex items-center rounded-xl border border-teal-700 px-3 py-1.5 font-medium text-teal-700 hover:bg-teal-50">Contáctanos</a>
     </nav>
@@ -138,6 +140,7 @@
             <li>Auditorías internas de cumplimiento y planes de acción.</li>
             <li>Gestión documental y trámites ante autoridades.</li>
           </ul>
+          <a href="/consultoria-ambiental-costa-rica/" class="mt-4 inline-flex items-center text-teal-700 hover:underline">Ver detalles →</a>
         </div>
         <div class="rounded-2xl bg-white border p-6">
           <h3 class="text-xl font-bold text-teal-700">Salud Ocupacional</h3>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -19,8 +19,8 @@
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://garuas.com/Cursos/bandera-azul.html</loc>
-    <lastmod>2025-08-21</lastmod>
+    <loc>https://garuas.com/Cursos/bandera-azul/</loc>
+    <lastmod>2025-08-22</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>


### PR DESCRIPTION
## Summary
- Add header links to Consultoría and Bandera Azul pages
- Link Consultoría service card to its dedicated page
- Move Bandera Azul webinar into its own folder and update sitemap

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a7fa204784832e914f65250e17ca40