### PR TITLE
Remove servicios links and add 404 redirect

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=/">
+    <title>Redireccionando…</title>
+  </head>
+  <body>
+    <p>Redireccionando a la página principal...</p>
+    <script>window.location.href='/'</script>
+  </body>
+</html>

--- a/Cursos/bandera-azul/index.html
+++ b/Cursos/bandera-azul/index.html
@@ -43,7 +43,7 @@
       </a>
       <nav class="text-sm hidden sm:flex gap-6">
         <a href="/" class="hover:text-sky-700">Inicio</a>
-        <a href="/servicios" class="hover:text-sky-700">Servicios</a>
+        <a href="/#servicios" class="hover:text-sky-700">Servicios</a>
         <a href="/Cursos/" class="text-sky-700 font-medium">Cursos</a>
         <a href="#registro" class="rounded-lg px-3 py-1.5 bg-sky-600 text-white hover:bg-sky-700">Registrarme</a>
       </nav>

--- a/Cursos/index.html
+++ b/Cursos/index.html
@@ -25,7 +25,7 @@
       </a>
       <nav class="text-sm hidden sm:flex gap-6">
         <a href="/" class="hover:text-sky-700">Inicio</a>
-        <a href="/servicios" class="hover:text-sky-700">Servicios</a>
+        <a href="/#servicios" class="hover:text-sky-700">Servicios</a>
         <a href="/Cursos/" class="text-sky-700 font-medium">Cursos</a>
       </nav>
     </div>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -20,7 +20,7 @@
   </url>
   <url>
     <loc>https://garuas.com/Cursos/bandera-azul/</loc>
-    <lastmod>2025-08-22</lastmod>
+    <lastmod>2025-08-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -35,5 +35,11 @@
     <lastmod>2025-08-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://garuas.com/404.html</loc>
+    <lastmod>2025-08-22</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
   </url>
 </urlset>


### PR DESCRIPTION
## Summary
- Redirect legacy /servicios navigation links to the homepage anchor
- Add 404.html that redirects missing pages back to home
- Include 404 page in sitemap

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7fcc9c70c832eac7da2cf70f4bd46