### PR TITLE
Link to courses page and remove inactive listing

### DIFF
--- a/Cursos/index.html
+++ b/Cursos/index.html
@@ -41,12 +41,6 @@
         <p class="mt-2 text-slate-700">Requisitos y pasos clave para empresas privadas en Costa Rica.</p>
         <a href="/Cursos/bandera-azul/" class="mt-4 inline-flex items-center text-sky-700 hover:underline">Ver detalles →</a>
       </article>
-
-      <article class="rounded-xl border p-6 bg-white">
-        <h2 class="text-xl font-semibold">Próximamente</h2>
-        <p class="mt-2 text-slate-700">Más cursos y eventos están en preparación.</p>
-        <span class="mt-4 inline-flex items-center text-slate-400">Por anunciar</span>
-      </article>
     </div>
   </main>
 

--- a/index.html
+++ b/index.html
@@ -83,7 +83,7 @@
       <a href="#servicios" class="hover:text-teal-700">Servicios</a>
       <a href="#sectores" class="hover:text-teal-700">Sectores</a>
       <a href="/consultoria-ambiental-costa-rica/" class="hover:text-teal-700">Consultoría</a>
-      <a href="/Cursos/bandera-azul/" class="hover:text-teal-700">Bandera Azul</a>
+      <a href="/Cursos/" class="hover:text-teal-700">Cursos</a>
       <a href="#nosotros" class="hover:text-teal-700">Nosotros</a>
       <a href="#contacto" class="inline-flex items-center rounded-xl border border-teal-700 px-3 py-1.5 font-medium text-teal-700 hover:bg-teal-50">Contáctanos</a>
     </nav>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://garuas.com/</loc>
-    <lastmod>2025-08-21</lastmod>
+    <lastmod>2025-08-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>1.0</priority>
   </url>
@@ -14,7 +14,7 @@
   </url>
   <url>
     <loc>https://garuas.com/Cursos/</loc>
-    <lastmod>2025-08-21</lastmod>
+    <lastmod>2025-08-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -38,7 +38,7 @@
   </url>
   <url>
     <loc>https://garuas.com/404.html</loc>
-    <lastmod>2025-08-22</lastmod>
+    <lastmod>2025-08-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>


### PR DESCRIPTION
## Summary
- Replace Bandera Azul navigation entry with a general Cursos link
- Show only active courses on Cursos page
- Refresh sitemap `lastmod` timestamps

## Testing
- `curl -I http://localhost:8000/Cursos/`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68abcefb7bac832e950523811ea9cfd4