### PR TITLE
feat: add mobile navigation menu

### DIFF
--- a/Cursos/bandera-azul/index.html
+++ b/Cursos/bandera-azul/index.html
@@ -41,13 +41,25 @@
         <img src="/assets/garua_logo_banner2_recortado.png" alt="Garúa" class="h-10 object-contain" />
         <span class="font-semibold tracking-wide">Garúa</span>
       </a>
-      <nav class="text-sm hidden sm:flex gap-6">
+      <button id="menu-button" class="md:hidden" aria-controls="mobile-menu" aria-expanded="false">
+        <span class="sr-only">Menú</span>
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 5.25h16.5M3.75 12h16.5m-16.5 6.75h16.5" />
+        </svg>
+      </button>
+      <nav class="hidden md:flex text-sm gap-6">
         <a href="/" class="hover:text-sky-700">Inicio</a>
         <a href="/#servicios" class="hover:text-sky-700">Servicios</a>
         <a href="/Cursos/" class="text-sky-700 font-medium">Cursos</a>
         <a href="#registro" class="rounded-lg px-3 py-1.5 bg-sky-600 text-white hover:bg-sky-700">Registrarme</a>
       </nav>
     </div>
+  <nav id="mobile-menu" class="md:hidden hidden flex flex-col gap-4 border-t px-4 pb-4 text-sm bg-white">
+    <a href="/" class="hover:text-sky-700">Inicio</a>
+    <a href="/#servicios" class="hover:text-sky-700">Servicios</a>
+    <a href="/Cursos/" class="hover:text-sky-700">Cursos</a>
+    <a href="#registro" class="hover:text-sky-700">Registrarme</a>
+  </nav>
   </header>
 
   <section class="w-full bg-gradient-to-br from-sky-50 to-white">
@@ -176,6 +188,27 @@
     </div>
   </footer>
 
+  <script>
+    const menuButton = document.getElementById("menu-button");
+    const mobileMenu = document.getElementById("mobile-menu");
+    menuButton.addEventListener("click", () => {
+      const expanded = menuButton.getAttribute("aria-expanded") == "true";
+      menuButton.setAttribute("aria-expanded", String(!expanded));
+      mobileMenu.classList.toggle("hidden");
+    });
+    document.addEventListener("keydown", (e) => {
+      if (e.key == "Escape") {
+        mobileMenu.classList.add("hidden");
+        menuButton.setAttribute("aria-expanded", "false");
+      }
+    });
+    mobileMenu.querySelectorAll("a").forEach((link) => {
+      link.addEventListener("click", () => {
+        mobileMenu.classList.add("hidden");
+        menuButton.setAttribute("aria-expanded", "false");
+      });
+    });
+  </script>
   <script>
     document.getElementById('y').textContent = new Date().getFullYear();
     const eventDate = new Date('2025-09-24T18:00:00-06:00').getTime();

--- a/Cursos/index.html
+++ b/Cursos/index.html
@@ -23,12 +23,23 @@
         <img src="/assets/garua_logo_banner2_recortado.png" alt="Garúa" class="h-10 object-contain" />
         <span class="font-semibold tracking-wide">Garúa</span>
       </a>
-      <nav class="text-sm hidden sm:flex gap-6">
+      <button id="menu-button" class="md:hidden" aria-controls="mobile-menu" aria-expanded="false">
+        <span class="sr-only">Menú</span>
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 5.25h16.5M3.75 12h16.5m-16.5 6.75h16.5" />
+        </svg>
+      </button>
+      <nav class="hidden md:flex text-sm gap-6">
         <a href="/" class="hover:text-sky-700">Inicio</a>
         <a href="/#servicios" class="hover:text-sky-700">Servicios</a>
         <a href="/Cursos/" class="text-sky-700 font-medium">Cursos</a>
       </nav>
     </div>
+  <nav id="mobile-menu" class="md:hidden hidden flex flex-col gap-4 border-t px-4 pb-4 text-sm bg-white">
+    <a href="/" class="hover:text-sky-700">Inicio</a>
+    <a href="/#servicios" class="hover:text-sky-700">Servicios</a>
+    <a href="/Cursos/" class="hover:text-sky-700">Cursos</a>
+  </nav>
   </header>
 
   <main class="mx-auto max-w-6xl px-4 py-12">
@@ -50,6 +61,27 @@
     </div>
   </footer>
 
+  <script>
+    const menuButton = document.getElementById("menu-button");
+    const mobileMenu = document.getElementById("mobile-menu");
+    menuButton.addEventListener("click", () => {
+      const expanded = menuButton.getAttribute("aria-expanded") == "true";
+      menuButton.setAttribute("aria-expanded", String(!expanded));
+      mobileMenu.classList.toggle("hidden");
+    });
+    document.addEventListener("keydown", (e) => {
+      if (e.key == "Escape") {
+        mobileMenu.classList.add("hidden");
+        menuButton.setAttribute("aria-expanded", "false");
+      }
+    });
+    mobileMenu.querySelectorAll("a").forEach((link) => {
+      link.addEventListener("click", () => {
+        mobileMenu.classList.add("hidden");
+        menuButton.setAttribute("aria-expanded", "false");
+      });
+    });
+  </script>
   <script>
     document.getElementById('y').textContent = new Date().getFullYear();
   </script>

--- a/consultoria-ambiental-costa-rica/index.html
+++ b/consultoria-ambiental-costa-rica/index.html
@@ -68,6 +68,12 @@
         <img src="/assets/logo.png" alt="Garúa" class="h-6 w-6 rounded-full bg-white object-contain" />
         <span class="font-bold tracking-wide text-teal-700 text-xl">GARÚA</span>
       </a>
+      <button id="menu-button" class="md:hidden" aria-controls="mobile-menu" aria-expanded="false">
+        <span class="sr-only">Menú</span>
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 5.25h16.5M3.75 12h16.5m-16.5 6.75h16.5" />
+        </svg>
+      </button>
       <nav class="hidden md:flex items-center gap-6 text-sm">
         <a href="/operacion-ptar-costa-rica/" class="hover:text-teal-700">Operación PTAR</a>
         <a href="/consultoria-ambiental-costa-rica/" class="text-teal-700 font-semibold">Consultoría ambiental</a>
@@ -75,6 +81,12 @@
         <a href="/#contacto" class="inline-flex items-center rounded-xl border border-teal-700 px-3 py-1.5 font-medium text-teal-700 hover:bg-teal-50">Contáctanos</a>
       </nav>
     </div>
+    <nav id="mobile-menu" class="md:hidden hidden flex flex-col gap-4 border-t px-4 pb-4 text-sm bg-white">
+      <a href="/operacion-ptar-costa-rica/" class="hover:text-teal-700">Operación PTAR</a>
+      <a href="/consultoria-ambiental-costa-rica/" class="hover:text-teal-700">Consultoría ambiental</a>
+      <a href="/salud-ocupacional-costa-rica/" class="hover:text-teal-700">Salud ocupacional</a>
+      <a href="/#contacto" class="hover:text-teal-700">Contáctanos</a>
+    </nav>
   </header>
 
   <!-- HERO -->
@@ -175,6 +187,27 @@
     </div>
   </footer>
 
+  <script>
+    const menuButton = document.getElementById("menu-button");
+    const mobileMenu = document.getElementById("mobile-menu");
+    menuButton.addEventListener("click", () => {
+      const expanded = menuButton.getAttribute("aria-expanded") == "true";
+      menuButton.setAttribute("aria-expanded", String(!expanded));
+      mobileMenu.classList.toggle("hidden");
+    });
+    document.addEventListener("keydown", (e) => {
+      if (e.key == "Escape") {
+        mobileMenu.classList.add("hidden");
+        menuButton.setAttribute("aria-expanded", "false");
+      }
+    });
+    mobileMenu.querySelectorAll("a").forEach((link) => {
+      link.addEventListener("click", () => {
+        mobileMenu.classList.add("hidden");
+        menuButton.setAttribute("aria-expanded", "false");
+      });
+    });
+  </script>
   <script>document.getElementById('year').textContent = new Date().getFullYear();</script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -79,6 +79,12 @@
     <a href="/" class="flex items-center gap-3">
       <span class="font-bold tracking-wide text-teal-700 text-xl">GARÚA</span>
     </a>
+    <button id="menu-button" class="md:hidden" aria-controls="mobile-menu" aria-expanded="false">
+      <span class="sr-only">Menú</span>
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 5.25h16.5M3.75 12h16.5m-16.5 6.75h16.5" />
+      </svg>
+    </button>
     <nav class="hidden md:flex items-center gap-6 text-sm">
       <a href="#servicios" class="hover:text-teal-700">Servicios</a>
       <a href="#sectores" class="hover:text-teal-700">Sectores</a>
@@ -88,6 +94,14 @@
       <a href="#contacto" class="inline-flex items-center rounded-xl border border-teal-700 px-3 py-1.5 font-medium text-teal-700 hover:bg-teal-50">Contáctanos</a>
     </nav>
   </div>
+  <nav id="mobile-menu" class="md:hidden hidden flex flex-col gap-4 border-t px-4 pb-4 text-sm bg-white">
+    <a href="#servicios" class="hover:text-teal-700">Servicios</a>
+    <a href="#sectores" class="hover:text-teal-700">Sectores</a>
+    <a href="/consultoria-ambiental-costa-rica/" class="hover:text-teal-700">Consultoría</a>
+    <a href="/Cursos/" class="hover:text-teal-700">Cursos</a>
+    <a href="#nosotros" class="hover:text-teal-700">Nosotros</a>
+    <a href="#contacto" class="hover:text-teal-700">Contáctanos</a>
+  </nav>
 </header>
 
 <!-- HERO -->
@@ -277,6 +291,27 @@
   </div>
 </footer>
 
+  <script>
+    const menuButton = document.getElementById("menu-button");
+    const mobileMenu = document.getElementById("mobile-menu");
+    menuButton.addEventListener("click", () => {
+      const expanded = menuButton.getAttribute("aria-expanded") == "true";
+      menuButton.setAttribute("aria-expanded", String(!expanded));
+      mobileMenu.classList.toggle("hidden");
+    });
+    document.addEventListener("keydown", (e) => {
+      if (e.key == "Escape") {
+        mobileMenu.classList.add("hidden");
+        menuButton.setAttribute("aria-expanded", "false");
+      }
+    });
+    mobileMenu.querySelectorAll("a").forEach((link) => {
+      link.addEventListener("click", () => {
+        mobileMenu.classList.add("hidden");
+        menuButton.setAttribute("aria-expanded", "false");
+      });
+    });
+  </script>
   <script>
     document.getElementById('year').textContent = new Date().getFullYear();
   </script>

--- a/operacion-ptar-costa-rica/index.html
+++ b/operacion-ptar-costa-rica/index.html
@@ -50,6 +50,12 @@
         <img src="/assets/logo.png" alt="Garúa" class="h-6 w-6 rounded-full bg-white object-contain" />
         <span class="font-bold tracking-wide text-teal-700 text-xl">GARÚA</span>
       </a>
+      <button id="menu-button" class="md:hidden" aria-controls="mobile-menu" aria-expanded="false">
+        <span class="sr-only">Menú</span>
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 5.25h16.5M3.75 12h16.5m-16.5 6.75h16.5" />
+        </svg>
+      </button>
       <nav class="hidden md:flex items-center gap-6 text-sm">
         <a href="/operacion-ptar-costa-rica/" class="text-teal-700 font-semibold">Operación PTAR</a>
         <a href="/consultoria-ambiental-costa-rica/" class="hover:text-teal-700">Consultoría ambiental</a>
@@ -57,6 +63,12 @@
         <a href="/#contacto" class="inline-flex items-center rounded-xl border border-teal-700 px-3 py-1.5 font-medium text-teal-700 hover:bg-teal-50">Contáctanos</a>
       </nav>
     </div>
+    <nav id="mobile-menu" class="md:hidden hidden flex flex-col gap-4 border-t px-4 pb-4 text-sm bg-white">
+      <a href="/operacion-ptar-costa-rica/" class="hover:text-teal-700">Operación PTAR</a>
+      <a href="/consultoria-ambiental-costa-rica/" class="hover:text-teal-700">Consultoría ambiental</a>
+      <a href="/salud-ocupacional-costa-rica/" class="hover:text-teal-700">Salud ocupacional</a>
+      <a href="/#contacto" class="hover:text-teal-700">Contáctanos</a>
+    </nav>
   </header>
 
   <!-- HERO -->
@@ -156,6 +168,27 @@
     </div>
   </footer>
 
+  <script>
+    const menuButton = document.getElementById("menu-button");
+    const mobileMenu = document.getElementById("mobile-menu");
+    menuButton.addEventListener("click", () => {
+      const expanded = menuButton.getAttribute("aria-expanded") == "true";
+      menuButton.setAttribute("aria-expanded", String(!expanded));
+      mobileMenu.classList.toggle("hidden");
+    });
+    document.addEventListener("keydown", (e) => {
+      if (e.key == "Escape") {
+        mobileMenu.classList.add("hidden");
+        menuButton.setAttribute("aria-expanded", "false");
+      }
+    });
+    mobileMenu.querySelectorAll("a").forEach((link) => {
+      link.addEventListener("click", () => {
+        mobileMenu.classList.add("hidden");
+        menuButton.setAttribute("aria-expanded", "false");
+      });
+    });
+  </script>
   <script>document.getElementById('year').textContent = new Date().getFullYear();</script>
 </body>
 </html>

--- a/salud-ocupacional-costa-rica/index.html
+++ b/salud-ocupacional-costa-rica/index.html
@@ -50,6 +50,12 @@
         <img src="/assets/logo.png" alt="Garúa" class="h-6 w-6 rounded-full bg-white object-contain" />
         <span class="font-bold tracking-wide text-teal-700 text-xl">GARÚA</span>
       </a>
+      <button id="menu-button" class="md:hidden" aria-controls="mobile-menu" aria-expanded="false">
+        <span class="sr-only">Menú</span>
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 5.25h16.5M3.75 12h16.5m-16.5 6.75h16.5" />
+        </svg>
+      </button>
       <nav class="hidden md:flex items-center gap-6 text-sm">
         <a href="/operacion-ptar-costa-rica/" class="hover:text-teal-700">Operación PTAR</a>
         <a href="/consultoria-ambiental-costa-rica/" class="hover:text-teal-700">Consultoría ambiental</a>
@@ -57,6 +63,12 @@
         <a href="/#contacto" class="inline-flex items-center rounded-xl border border-teal-700 px-3 py-1.5 font-medium text-teal-700 hover:bg-teal-50">Contáctanos</a>
       </nav>
     </div>
+    <nav id="mobile-menu" class="md:hidden hidden flex flex-col gap-4 border-t px-4 pb-4 text-sm bg-white">
+      <a href="/operacion-ptar-costa-rica/" class="hover:text-teal-700">Operación PTAR</a>
+      <a href="/consultoria-ambiental-costa-rica/" class="hover:text-teal-700">Consultoría ambiental</a>
+      <a href="/salud-ocupacional-costa-rica/" class="hover:text-teal-700">Salud ocupacional</a>
+      <a href="/#contacto" class="hover:text-teal-700">Contáctanos</a>
+    </nav>
   </header>
 
   <!-- HERO -->
@@ -156,6 +168,27 @@
     </div>
   </footer>
 
+  <script>
+    const menuButton = document.getElementById("menu-button");
+    const mobileMenu = document.getElementById("mobile-menu");
+    menuButton.addEventListener("click", () => {
+      const expanded = menuButton.getAttribute("aria-expanded") == "true";
+      menuButton.setAttribute("aria-expanded", String(!expanded));
+      mobileMenu.classList.toggle("hidden");
+    });
+    document.addEventListener("keydown", (e) => {
+      if (e.key == "Escape") {
+        mobileMenu.classList.add("hidden");
+        menuButton.setAttribute("aria-expanded", "false");
+      }
+    });
+    mobileMenu.querySelectorAll("a").forEach((link) => {
+      link.addEventListener("click", () => {
+        mobileMenu.classList.add("hidden");
+        menuButton.setAttribute("aria-expanded", "false");
+      });
+    });
+  </script>
   <script>document.getElementById('year').textContent = new Date().getFullYear();</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add hamburger button for mobile navigation
- implement toggle script with accessibility attributes
- copy desktop links into collapsible mobile menu on all pages

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68abd070dcf0832e9c36836753c45214