### PR TITLE
Add staging pre-evaluation page for concesion de agua superficial

### DIFF
--- a/README_STAGING.md
+++ b/README_STAGING.md
@@ -1,0 +1,37 @@
+# Evaluación de viabilidad de concesión de agua superficial (staging)
+
+Esta página de evaluación de viabilidad se publica únicamente en el entorno de staging y debe compartirse solo con clientes que cuenten con el enlace privado.
+
+## Acceso restringido
+
+- Ruta completa: `/staging/concesion-superficial-4a83002e/?t=8b6a5213-7c50-4967-a0a2-35d26f260841`
+- El token (`t`) es obligatorio. Sin ese parámetro la página muestra un 404 suave y no revela contenido.
+- No enlazar esta URL desde la navegación pública ni incluirla en `sitemap.xml`.
+- Si se requiere regenerar el token:
+  1. Generar un nuevo UUID.
+  2. Actualizar el atributo `data-access-token` en `staging/concesion-superficial/index.html` y `staging/concesion-superficial-4a83002e/index.html`.
+  3. Ajustar la URL comunicada al cliente con el nuevo valor de `t`.
+
+## Protección frente a motores de búsqueda
+
+- Ambas páginas incluyen `meta` tags `noindex, nofollow` y sugerencias de cabeceras `X-Robots-Tag` en comentarios.
+- Mantener bloqueado el directorio `/staging/` en `robots.txt` cuando el entorno lo permita.
+
+## Envío de datos
+
+- El formulario intenta enviar un `POST` JSON a `/api/pre-evaluacion`.
+- Si el endpoint no existe en el entorno de staging, la aplicación hace fallback a un `mailto:info@garuas.com` con el resumen de la solicitud.
+- Se registra la latitud y longitud seleccionada en el mapa junto con las respuestas del cuestionario y el estado preliminar (`admisible` o `requiere revisión`).
+
+## Pruebas recomendadas
+
+1. Abrir la URL con el token válido y completar el formulario con todas las respuestas favorables para verificar el mensaje de "admisible preliminar".
+2. Repetir la prueba marcando respuestas que activen "requiere revisión" (por ejemplo, contestar "No" en obligaciones) y confirmar el mensaje de seguimiento en &lt;24 h.
+3. Hacer clic en el mapa para confirmar que se crea y actualiza el marcador, y que los campos de latitud/longitud se llenan.
+4. Revisar la consola del navegador para validar el intento de `POST` y el fallback `mailto` si no hay endpoint.
+
+## Seguridad
+
+- Evitar compartir la URL fuera de canales controlados.
+- Si el enlace se filtra, generar un nuevo token y actualizar los archivos mencionados.
+- No habilitar analytics ni scripts de terceros en esta página mientras esté en staging.

--- a/staging/concesion-superficial-4a83002e/index.html
+++ b/staging/concesion-superficial-4a83002e/index.html
@@ -1,0 +1,388 @@
+<!DOCTYPE html>
+<html lang="es" class="h-full">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Garúa · Evaluación de viabilidad de concesión de agua superficial</title>
+    <meta
+      name="description"
+      content="Evaluación de viabilidad y cotización preliminar para concesión de agua superficial con Garúa."
+    />
+    <meta name="robots" content="noindex,nofollow" />
+    <meta name="googlebot" content="noindex,nofollow" />
+    <!-- X-Robots-Tag header snippet suggestions:
+      Netlify: [[headers]]\n  for = "/staging/concesion-superficial*"\n  [headers.values]\n  X-Robots-Tag = "noindex, nofollow"
+      NGINX: add_header X-Robots-Tag "noindex, nofollow"; (within location /staging/)
+      Apache: Header set X-Robots-Tag "noindex, nofollow" (in <Location "/staging/">)
+    -->
+    <!-- Para reforzar privacidad, bloquee /staging/ en robots.txt si el entorno lo permite. -->
+    <link rel="icon" href="/assets/favicon.svg" />
+    <link
+      rel="stylesheet"
+      href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
+      integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY="
+      crossorigin=""
+    />
+    <script src="https://cdn.tailwindcss.com?plugins=forms"></script>
+    <script>
+      tailwind.config = {
+        theme: {
+          extend: {
+            colors: {
+              primary: {
+                50: '#edf6f9',
+                100: '#d8eef1',
+                500: '#3b9d8f',
+                600: '#2f7c72',
+              },
+            },
+          },
+        },
+      };
+    </script>
+    <style>
+      .option-btn {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        border-radius: 9999px;
+        border: 1px solid rgba(148, 163, 184, 0.6);
+        padding: 0.6rem 1.5rem;
+        font-size: 0.95rem;
+        font-weight: 600;
+        color: rgb(71, 85, 105);
+        background: white;
+        transition: all 0.2s ease;
+        box-shadow: inset 0 0 0 0 rgba(59, 157, 143, 0);
+      }
+      .option-btn:hover,
+      .option-btn:focus-visible {
+        border-color: rgba(59, 157, 143, 0.7);
+        box-shadow: 0 0 0 3px rgba(59, 157, 143, 0.15);
+        outline: none;
+      }
+      .option-btn[aria-pressed='true'] {
+        background: linear-gradient(135deg, #3b9d8f, #2f7c72);
+        color: white;
+        border-color: transparent;
+        box-shadow: inset 0 0 0 0 rgba(59, 157, 143, 0.2);
+      }
+      .option-btn[disabled] {
+        opacity: 0.5;
+        cursor: not-allowed;
+      }
+    </style>
+  </head>
+  <body class="min-h-full bg-slate-50 text-slate-800" data-access-token="8b6a5213-7c50-4967-a0a2-35d26f260841">
+    <div id="restricted" class="min-h-screen flex items-center justify-center p-6">
+      <div class="max-w-md text-center bg-white shadow-lg rounded-2xl p-8">
+        <h1 class="text-2xl font-semibold text-slate-900">Página no disponible</h1>
+        <p class="mt-4 text-slate-600">
+          Necesita un enlace válido para acceder a esta evaluación de viabilidad. Si cree que es un
+          error,
+          contacte a <a class="text-primary-600 font-semibold" href="mailto:info@garuas.com">info@garuas.com</a>.
+        </p>
+      </div>
+    </div>
+    <div id="page" class="hidden">
+      <div class="relative overflow-hidden">
+        <div class="absolute inset-0 pointer-events-none" aria-hidden="true">
+          <div class="absolute -top-10 -right-16 h-48 w-48 rounded-full bg-primary-50"></div>
+          <div class="absolute bottom-0 left-10 h-32 w-32 rounded-full bg-primary-100"></div>
+        </div>
+        <div class="relative mx-auto max-w-6xl px-4 py-10 sm:px-6 lg:px-8">
+          <header class="mb-10">
+            <div class="flex flex-col gap-6 sm:flex-row sm:items-center sm:justify-between">
+              <div class="flex items-center gap-4">
+                <div class="flex h-14 w-14 items-center justify-center rounded-full bg-primary-100">
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 64 64"
+                    class="h-10 w-10 text-primary-600"
+                    aria-hidden="true"
+                  >
+                    <path
+                      fill="currentColor"
+                      d="M33 4c-7.2 9.4-17.4 23-17.4 32.2 0 9.9 7.7 17.8 17.4 17.8s17.4-7.9 17.4-17.8C50.4 27 40.2 13.4 33 4zm0 43.6c-6.1 0-11-5.1-11-11.4 0-3.4 2.3-7.9 6.9-14.4 1.4 2.5 3.5 5.5 6.2 8.7 4.3 5.1 4.9 7.7 4.9 10.1 0 6.3-4.9 11.4-11 11.4z"
+                    />
+                  </svg>
+                  <span class="sr-only">Garúa</span>
+                </div>
+                <div>
+                  <p class="text-sm uppercase tracking-wide text-primary-600">Garúa</p>
+                  <h1 class="text-2xl font-semibold text-slate-900">
+                    Evaluación de viabilidad de concesión de agua superficial
+                  </h1>
+                </div>
+              </div>
+              <p class="rounded-full bg-white/90 px-4 py-2 text-sm font-medium text-primary-600 shadow-sm">
+                Respuesta en &lt; 24 h con viabilidad y cotización preliminar
+              </p>
+            </div>
+          </header>
+          <main class="grid gap-8 lg:grid-cols-[minmax(0,1fr)_360px]">
+            <section>
+              <div class="mb-6">
+                <div class="flex items-center justify-between">
+                  <p class="text-sm font-medium text-slate-600">Progreso</p>
+                  <span id="progress-label" class="text-sm font-semibold text-primary-600">0%</span>
+                </div>
+                <div class="mt-2 h-2 rounded-full bg-slate-200">
+                  <div id="progress-bar" class="h-full w-0 rounded-full bg-primary-500 transition-all"></div>
+                </div>
+              </div>
+              <div
+                id="formMessage"
+                class="hidden rounded-2xl border border-amber-200 bg-amber-50 p-4 text-sm text-amber-700"
+                role="alert"
+                aria-live="assertive"
+              ></div>
+              <form id="preEvalForm" class="space-y-8" novalidate>
+                <input type="text" name="empresa" autocomplete="off" class="hidden" tabindex="-1" aria-hidden="true" />
+                <fieldset class="space-y-6 rounded-2xl bg-white p-6 shadow-sm">
+                  <legend class="text-lg font-semibold text-slate-900">Datos de contacto</legend>
+                  <div>
+                    <label for="nombre" class="block text-sm font-medium text-slate-700">Nombre y apellidos *</label>
+                    <input
+                      id="nombre"
+                      name="nombre"
+                      type="text"
+                      required
+                      autocomplete="name"
+                      class="mt-1 block w-full rounded-xl border-slate-200 bg-slate-50 focus:border-primary-500 focus:ring-primary-500"
+                    />
+                  </div>
+                  <div>
+                    <label for="correo" class="block text-sm font-medium text-slate-700">Correo electrónico *</label>
+                    <input
+                      id="correo"
+                      name="correo"
+                      type="email"
+                      required
+                      autocomplete="email"
+                      class="mt-1 block w-full rounded-xl border-slate-200 bg-slate-50 focus:border-primary-500 focus:ring-primary-500"
+                    />
+                  </div>
+                  <div>
+                    <label for="telefono" class="block text-sm font-medium text-slate-700">Teléfono o WhatsApp *</label>
+                    <input
+                      id="telefono"
+                      name="telefono"
+                      type="tel"
+                      required
+                      autocomplete="tel"
+                      class="mt-1 block w-full rounded-xl border-slate-200 bg-slate-50 focus:border-primary-500 focus:ring-primary-500"
+                    />
+                  </div>
+                </fieldset>
+
+                <fieldset class="space-y-4 rounded-2xl bg-white p-6 shadow-sm">
+                  <legend class="text-lg font-semibold text-slate-900">Ubicación aproximada</legend>
+                  <p class="text-sm text-slate-600">
+                    Haga clic para marcar el punto más aproximado de la naciente. Puede mover el mapa para ubicarla.
+                  </p>
+                  <div class="h-72 overflow-hidden rounded-2xl" id="map" role="region" aria-label="Mapa para ubicar la naciente"></div>
+                  <div class="grid gap-4 sm:grid-cols-2">
+                    <div>
+                      <label for="lat" class="block text-sm font-medium text-slate-700">Latitud *</label>
+                      <input
+                        id="lat"
+                        name="lat"
+                        type="text"
+                        readonly
+                        required
+                        class="mt-1 block w-full rounded-xl border-slate-200 bg-slate-100 focus:border-primary-500 focus:ring-primary-500"
+                      />
+                    </div>
+                    <div>
+                      <label for="lng" class="block text-sm font-medium text-slate-700">Longitud *</label>
+                      <input
+                        id="lng"
+                        name="lng"
+                        type="text"
+                        readonly
+                        required
+                        class="mt-1 block w-full rounded-xl border-slate-200 bg-slate-100 focus:border-primary-500 focus:ring-primary-500"
+                      />
+                    </div>
+                  </div>
+                </fieldset>
+
+                <section class="space-y-6">
+                  <h2 class="text-lg font-semibold text-slate-900">Cuestionario</h2>
+
+                  <div class="space-y-6">
+                    <article class="rounded-2xl bg-white p-6 shadow-sm" data-step="q1">
+                      <h3 class="text-base font-semibold text-slate-900">
+                        ¿Es usted propietario del inmueble o de los inmuebles donde se pretende realizar el aprovechamiento del agua?
+                      </h3>
+                      <div class="mt-4 flex flex-wrap gap-3" role="radiogroup" aria-labelledby="q1-label">
+                        <button type="button" class="option-btn" data-question="q1" data-value="si">Sí</button>
+                        <button type="button" class="option-btn" data-question="q1" data-value="no">No</button>
+                      </div>
+                      <div class="mt-4 hidden space-y-3" data-follow-up="q1">
+                        <p class="text-sm text-slate-600">¿Cuenta con un poder notarial que lo autorice a realizar la solicitud?</p>
+                        <div class="flex flex-wrap gap-3" role="radiogroup">
+                          <button type="button" class="option-btn" data-question="q1b" data-value="si">Sí</button>
+                          <button type="button" class="option-btn" data-question="q1b" data-value="no">No</button>
+                        </div>
+                      </div>
+                    </article>
+
+                    <article class="rounded-2xl bg-white p-6 shadow-sm" data-step="q2">
+                      <h3 class="text-base font-semibold text-slate-900">
+                        ¿La propiedad está inscrita en el Registro Nacional de la Propiedad?
+                      </h3>
+                      <div class="mt-4 flex flex-wrap gap-3" role="radiogroup">
+                        <button type="button" class="option-btn" data-question="q2" data-value="si">Sí</button>
+                        <button type="button" class="option-btn" data-question="q2" data-value="no">No</button>
+                      </div>
+                      <div class="mt-4 hidden space-y-3" data-follow-up="q2">
+                        <p class="text-sm text-slate-600">¿Está en proceso de regularización como información posesoria?</p>
+                        <div class="flex flex-wrap gap-3" role="radiogroup">
+                          <button type="button" class="option-btn" data-question="q2b" data-value="si">Sí</button>
+                          <button type="button" class="option-btn" data-question="q2b" data-value="no">No</button>
+                        </div>
+                      </div>
+                    </article>
+
+                    <article class="rounded-2xl bg-white p-6 shadow-sm" data-step="q3">
+                      <h3 class="text-base font-semibold text-slate-900">¿Está al día con Hacienda, CCSS y la DA?</h3>
+                      <div class="mt-4 flex flex-wrap gap-3" role="radiogroup">
+                        <button type="button" class="option-btn" data-question="q3" data-value="si">Sí</button>
+                        <button type="button" class="option-btn" data-question="q3" data-value="no">No</button>
+                      </div>
+                      <p class="mt-4 hidden rounded-xl border border-amber-200 bg-amber-50 p-3 text-sm text-amber-700" data-alert="q3">
+                        Debe regularizarse ante Hacienda, CCSS y la Dirección de Aguas para avanzar con la concesión.
+                      </p>
+                    </article>
+
+                    <article class="rounded-2xl bg-white p-6 shadow-sm" data-step="q5">
+                      <h3 class="text-base font-semibold text-slate-900">¿La fuente se encuentra dentro de un Parque Nacional?</h3>
+                      <div class="mt-4 flex flex-wrap gap-3" role="radiogroup">
+                        <button type="button" class="option-btn" data-question="q5" data-value="si">Sí</button>
+                        <button type="button" class="option-btn" data-question="q5" data-value="no">No</button>
+                      </div>
+                      <div class="mt-4 hidden space-y-3" data-follow-up="q5">
+                        <p class="text-sm text-slate-600">¿La propiedad solicitante también está dentro del Parque Nacional?</p>
+                        <div class="flex flex-wrap gap-3" role="radiogroup">
+                          <button type="button" class="option-btn" data-question="q5b" data-value="si">Sí</button>
+                          <button type="button" class="option-btn" data-question="q5b" data-value="no">No</button>
+                        </div>
+                      </div>
+                    </article>
+
+                    <article class="rounded-2xl bg-white p-6 shadow-sm" data-step="q6">
+                      <h3 class="text-base font-semibold text-slate-900">
+                        ¿La conducción del agua hasta su propiedad NO atraviesa terrenos de terceros?
+                      </h3>
+                      <div class="mt-4 flex flex-wrap gap-3" role="radiogroup">
+                        <button type="button" class="option-btn" data-question="q6" data-value="si">Sí</button>
+                        <button type="button" class="option-btn" data-question="q6" data-value="no">No</button>
+                      </div>
+                      <div class="mt-4 hidden space-y-3" data-follow-up="q6">
+                        <p class="text-sm text-slate-600">¿Cuenta con autorización de los propietarios involucrados?</p>
+                        <div class="flex flex-wrap gap-3" role="radiogroup">
+                          <button type="button" class="option-btn" data-question="q6b" data-value="si">Sí</button>
+                          <button type="button" class="option-btn" data-question="q6b" data-value="no">No</button>
+                        </div>
+                        <div class="hidden space-y-3" data-follow-up="q6b">
+                          <p class="text-sm text-slate-600">¿Puede conducir por cauce de dominio público (río/quebrada)?</p>
+                          <div class="flex flex-wrap gap-3" role="radiogroup">
+                            <button type="button" class="option-btn" data-question="q6c" data-value="si">Sí</button>
+                            <button type="button" class="option-btn" data-question="q6c" data-value="no">No</button>
+                          </div>
+                        </div>
+                      </div>
+                      <p class="mt-4 hidden rounded-xl border border-amber-200 bg-amber-50 p-3 text-sm text-amber-700" data-alert="q6">
+                        Si requiere servidumbre forzosa o acuerdo privado, podemos asesorarle durante la evaluación.
+                      </p>
+                    </article>
+
+                    <article class="rounded-2xl bg-white p-6 shadow-sm" data-step="q7">
+                      <h3 class="text-base font-semibold text-slate-900">¿El uso es para consumo humano (agua potable)?</h3>
+                      <div class="mt-4 flex flex-wrap gap-3" role="radiogroup">
+                        <button type="button" class="option-btn" data-question="q7" data-value="si">Sí</button>
+                        <button type="button" class="option-btn" data-question="q7" data-value="no">No</button>
+                      </div>
+                      <div class="mt-4 hidden rounded-xl border border-primary-100 bg-primary-50 p-3 text-sm text-primary-700" data-alert="q7">
+                        El uso de agua para consumo humano está restringido a un proveedor estatal. ¿Desea continuar la solicitud para usos adicionales?
+                        <div class="mt-3 flex flex-wrap gap-3">
+                          <button type="button" class="option-btn" data-question="q7b" data-value="si">Sí</button>
+                          <button type="button" class="option-btn" data-question="q7b" data-value="no">No</button>
+                        </div>
+                      </div>
+                    </article>
+
+                    <article class="rounded-2xl bg-white p-6 shadow-sm" data-step="q8">
+                      <h3 class="text-base font-semibold text-slate-900">¿El aprovechamiento se encuentra fuera de áreas de protección?</h3>
+                      <div class="mt-4 flex flex-wrap gap-3" role="radiogroup">
+                        <button type="button" class="option-btn" data-question="q8" data-value="si">Sí</button>
+                        <button type="button" class="option-btn" data-question="q8" data-value="no">No</button>
+                      </div>
+                    </article>
+                  </div>
+                </section>
+
+                <div class="flex flex-col gap-4 rounded-2xl bg-white p-6 shadow-sm">
+                  <button
+                    type="submit"
+                    class="w-full rounded-full bg-primary-600 px-6 py-3 text-base font-semibold text-white shadow-lg transition hover:bg-primary-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-600"
+                  >
+                    Enviar pre-evaluación
+                  </button>
+                  <p class="text-xs text-slate-500">
+                    Su información se usará únicamente para evaluar viabilidad y cotizar. No compartimos datos con terceros.
+                  </p>
+                </div>
+              </form>
+              <div id="confirmation" class="hidden rounded-2xl bg-white p-8 text-center shadow-sm">
+                <h2 class="text-2xl font-semibold text-slate-900">¡Gracias!</h2>
+                <p id="confirmation-message" class="mt-4 text-sm text-slate-600"></p>
+                <button
+                  type="button"
+                  id="backButton"
+                  class="mt-6 inline-flex items-center justify-center rounded-full border border-primary-600 px-5 py-2 text-sm font-semibold text-primary-600 transition hover:bg-primary-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-600"
+                >
+                  Registrar otra solicitud
+                </button>
+              </div>
+            </section>
+
+            <aside class="space-y-6">
+              <div class="rounded-2xl bg-white p-6 shadow-sm">
+                <h2 class="text-lg font-semibold text-slate-900">Ubicación referencial</h2>
+                <p class="mt-2 text-sm text-slate-600">
+                  Ajuste el mapa para que nuestro equipo cuente con un punto de partida en la inspección.
+                </p>
+                <ul class="mt-4 space-y-2 text-sm text-slate-500">
+                  <li>• Puede mover el marcador haciendo clic nuevamente.</li>
+                  <li>• Si necesita asistencia, llámenos o escriba a <a class="text-primary-600 font-semibold" href="mailto:info@garuas.com">info@garuas.com</a>.</li>
+                  <li>• En algunos casos coordinamos visita técnica y valoración ambiental.</li>
+                </ul>
+              </div>
+              <div class="rounded-2xl bg-white p-6 shadow-sm">
+                <h2 class="text-lg font-semibold text-slate-900">Contacto</h2>
+                <p class="mt-2 text-sm text-slate-600">info@garuas.com · +506 0000-0000</p>
+              </div>
+            </aside>
+          </main>
+        </div>
+      </div>
+      <footer class="border-t border-slate-200 bg-white/70">
+        <div class="mx-auto flex max-w-6xl flex-col gap-3 px-4 py-6 text-sm text-slate-500 sm:flex-row sm:items-center sm:justify-between">
+          <p>&copy; <span id="year"></span> Garúa. Todos los derechos reservados.</p>
+          <p>Aviso de privacidad: Su información se usa solo para evaluar viabilidad y cotizar. No compartimos datos con terceros.</p>
+        </div>
+      </footer>
+    </div>
+
+    <script
+      src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
+      integrity="sha256-o9N1j7kP5Uft+RmseQGhX8Ss4i/WZk+3A1X3x0i0XvY="
+      crossorigin=""
+      defer
+    ></script>
+    <script src="/staging/concesion-superficial/app.js" type="module" defer></script>
+  </body>
+</html>

--- a/staging/concesion-superficial/app.js
+++ b/staging/concesion-superficial/app.js
@@ -1,0 +1,402 @@
+const body = document.body;
+const page = document.getElementById('page');
+const restricted = document.getElementById('restricted');
+const requiredToken = body?.dataset?.accessToken || '';
+const providedToken = new URLSearchParams(window.location.search).get('t');
+
+function showRestricted() {
+  if (restricted) {
+    restricted.classList.remove('hidden');
+  }
+  if (page) {
+    page.classList.add('hidden');
+  }
+}
+
+if (requiredToken && requiredToken !== providedToken) {
+  showRestricted();
+  console.warn('Token inválido o ausente. Acceso restringido.');
+  throw new Error('Acceso restringido: token inválido.');
+}
+
+if (page) {
+  page.classList.remove('hidden');
+}
+if (restricted) {
+  restricted.classList.add('hidden');
+}
+
+document.getElementById('year').textContent = new Date().getFullYear();
+
+const form = document.getElementById('preEvalForm');
+const confirmation = document.getElementById('confirmation');
+const confirmationMessage = document.getElementById('confirmation-message');
+const backButton = document.getElementById('backButton');
+const progressBar = document.getElementById('progress-bar');
+const progressLabel = document.getElementById('progress-label');
+const messageBox = document.getElementById('formMessage');
+const latInput = document.getElementById('lat');
+const lngInput = document.getElementById('lng');
+
+const state = {
+  respuestas: {},
+};
+
+const baseQuestions = ['q1', 'q2', 'q3', 'q5', 'q6', 'q7', 'q8'];
+
+const followUpsConfig = {
+  q1: {
+    key: 'q1b',
+    container: document.querySelector('[data-follow-up="q1"]'),
+    showWhen: (value) => value === 'no',
+  },
+  q2: {
+    key: 'q2b',
+    container: document.querySelector('[data-follow-up="q2"]'),
+    showWhen: (value) => value === 'no',
+  },
+  q5: {
+    key: 'q5b',
+    container: document.querySelector('[data-follow-up="q5"]'),
+    showWhen: (value) => value === 'si',
+  },
+  q6: {
+    key: 'q6b',
+    container: document.querySelector('[data-follow-up="q6"]'),
+    showWhen: (value) => value === 'no',
+  },
+  q6b: {
+    key: 'q6c',
+    container: document.querySelector('[data-follow-up="q6b"]'),
+    showWhen: (value) => value === 'no',
+  },
+  q7: {
+    key: 'q7b',
+    container: document.querySelector('[data-alert="q7"]'),
+    showWhen: (value) => value === 'si',
+  },
+};
+
+const alertBoxes = {
+  q3: document.querySelector('[data-alert="q3"]'),
+  q6: document.querySelector('[data-alert="q6"]'),
+};
+
+let map;
+let marker;
+
+document.querySelectorAll('.option-btn').forEach((button) => {
+  button.setAttribute('aria-pressed', 'false');
+  button.addEventListener('click', () => {
+    handleResponse(button.dataset.question, button.dataset.value);
+  });
+});
+
+Object.values(followUpsConfig).forEach((config) => {
+  if (config?.container) {
+    config.container.setAttribute('aria-hidden', 'true');
+  }
+});
+
+Object.values(alertBoxes).forEach((box) => {
+  box?.classList.add('hidden');
+  box?.setAttribute('aria-hidden', 'true');
+});
+
+function resetQuestion(key) {
+  if (!key) return;
+  delete state.respuestas[key];
+  const buttons = document.querySelectorAll(`.option-btn[data-question="${key}"]`);
+  buttons.forEach((btn) => {
+    btn.setAttribute('aria-pressed', 'false');
+  });
+}
+
+function toggleContainer(container, show) {
+  if (!container) return;
+  container.classList.toggle('hidden', !show);
+  container.setAttribute('aria-hidden', show ? 'false' : 'true');
+}
+
+function getActiveQuestions() {
+  const active = [...baseQuestions];
+  if (state.respuestas.q1 === 'no') active.push('q1b');
+  if (state.respuestas.q2 === 'no') active.push('q2b');
+  if (state.respuestas.q5 === 'si') active.push('q5b');
+  if (state.respuestas.q6 === 'no') {
+    active.push('q6b');
+    if (state.respuestas.q6b === 'no') {
+      active.push('q6c');
+    }
+  }
+  if (state.respuestas.q7 === 'si') active.push('q7b');
+  return active;
+}
+
+function updateProgress() {
+  const active = getActiveQuestions();
+  const answered = active.filter((key) => Boolean(state.respuestas[key])).length;
+  const progress = active.length ? Math.round((answered / active.length) * 100) : 0;
+  progressBar.style.width = `${progress}%`;
+  progressLabel.textContent = `${progress}%`;
+}
+
+function evaluateEstado() {
+  const motivos = [];
+  let requiereRevision = false;
+
+  if (state.respuestas.q1 === 'no' && state.respuestas.q1b !== 'si') {
+    requiereRevision = true;
+    motivos.push('Se requiere poder notarial vigente del propietario.');
+  }
+
+  if (state.respuestas.q2 === 'no' && state.respuestas.q2b !== 'si') {
+    requiereRevision = true;
+    motivos.push('Es necesario completar la inscripción registral o información posesoria.');
+  }
+
+  if (state.respuestas.q3 === 'no') {
+    requiereRevision = true;
+    motivos.push('Debe regularizar obligaciones con Hacienda, CCSS y la Dirección de Aguas.');
+  }
+
+  if (state.respuestas.q5 === 'si' && state.respuestas.q5b !== 'si') {
+    requiereRevision = true;
+    motivos.push('Cuando la fuente está en Parque Nacional, la propiedad solicitante debe estar dentro del área.');
+  }
+
+  if (state.respuestas.q6 === 'no') {
+    if (state.respuestas.q6b !== 'si') {
+      if (state.respuestas.q6c !== 'si') {
+        requiereRevision = true;
+        motivos.push('Requiere servidumbre forzosa o acuerdo privado para conducir el agua.');
+      }
+    }
+  }
+
+  if (state.respuestas.q7 === 'si' && state.respuestas.q7b !== 'si') {
+    requiereRevision = true;
+    motivos.push('El uso para consumo humano requiere un proveedor estatal autorizado.');
+  }
+
+  if (state.respuestas.q8 === 'no') {
+    requiereRevision = true;
+    motivos.push('El aprovechamiento está dentro de un área de protección.');
+  }
+
+  const baseAnswered = baseQuestions.every((key) => Boolean(state.respuestas[key]));
+  const admisiblePreliminar = !requiereRevision && baseAnswered && state.respuestas.q8 === 'si';
+
+  return { requiereRevision, motivos, admisiblePreliminar };
+}
+
+function showMessage(text) {
+  if (!messageBox) return;
+  if (!text) {
+    messageBox.classList.add('hidden');
+    messageBox.textContent = '';
+    return;
+  }
+  messageBox.textContent = text;
+  messageBox.classList.remove('hidden');
+}
+
+function handleResponse(question, value) {
+  state.respuestas[question] = value;
+  const groupButtons = document.querySelectorAll(`.option-btn[data-question="${question}"]`);
+  groupButtons.forEach((btn) => {
+    const isActive = btn.dataset.value === value;
+    btn.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+  });
+
+  if (followUpsConfig[question]) {
+    const { key, container, showWhen } = followUpsConfig[question];
+    const shouldShow = showWhen ? showWhen(value) : false;
+    toggleContainer(container, shouldShow);
+    if (!shouldShow) {
+      resetQuestion(key);
+      if (question === 'q6') resetQuestion('q6c');
+    }
+  }
+
+  if (question === 'q6b' && value !== 'no') {
+    const nested = followUpsConfig.q6b?.container;
+    toggleContainer(nested, false);
+    resetQuestion('q6c');
+  }
+
+  if (question === 'q7' && value !== 'si') {
+    resetQuestion('q7b');
+  }
+
+  if (alertBoxes.q3) {
+    const showQ3 = state.respuestas.q3 === 'no';
+    alertBoxes.q3.classList.toggle('hidden', !showQ3);
+    alertBoxes.q3.setAttribute('aria-hidden', showQ3 ? 'false' : 'true');
+  }
+
+  const showQ6 =
+    state.respuestas.q6 === 'no' && state.respuestas.q6b === 'no' && state.respuestas.q6c === 'no';
+  if (alertBoxes.q6) {
+    alertBoxes.q6.classList.toggle('hidden', !showQ6);
+    alertBoxes.q6.setAttribute('aria-hidden', showQ6 ? 'false' : 'true');
+  }
+
+  updateProgress();
+  showMessage('');
+}
+
+function getPayload() {
+  const estado = evaluateEstado();
+  return {
+    nombre: form.nombre.value.trim(),
+    correo: form.correo.value.trim(),
+    telefono: form.telefono.value.trim(),
+    lat: latInput.value.trim(),
+    lng: lngInput.value.trim(),
+    respuestas: {
+      q1: state.respuestas.q1 || null,
+      q1b: state.respuestas.q1b || null,
+      q2: state.respuestas.q2 || null,
+      q2b: state.respuestas.q2b || null,
+      q3: state.respuestas.q3 || null,
+      q5: state.respuestas.q5 || null,
+      q5b: state.respuestas.q5b || null,
+      q6: state.respuestas.q6 || null,
+      q6b: state.respuestas.q6b || null,
+      q6c: state.respuestas.q6c || null,
+      q7: state.respuestas.q7 || null,
+      q7b: state.respuestas.q7b || null,
+      q8: state.respuestas.q8 || null,
+    },
+    estado: {
+      admisiblePreliminar: estado.admisiblePreliminar,
+      requiereRevision: estado.requiereRevision,
+      motivos: estado.motivos,
+    },
+    userAgent: navigator.userAgent,
+    timestampISO: new Date().toISOString(),
+  };
+}
+
+async function sendPayload(payload) {
+  const endpoint = '/api/pre-evaluacion';
+  try {
+    const response = await fetch(endpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    if (!response.ok) {
+      throw new Error(`Error ${response.status}`);
+    }
+    console.info('Payload enviado a webhook', payload);
+    return true;
+  } catch (error) {
+    console.warn('No se pudo enviar al webhook, usando mailto fallback.', error);
+    const resumen = encodeURIComponent(
+      `Nombre: ${payload.nombre}\nCorreo: ${payload.correo}\nTeléfono: ${payload.telefono}\nLat/Lng: ${payload.lat}, ${payload.lng}\nRespuestas: ${JSON.stringify(payload.respuestas, null, 2)}\nEstado: ${JSON.stringify(payload.estado, null, 2)}\nUser-Agent: ${payload.userAgent}\nTimestamp: ${payload.timestampISO}`
+    );
+    window.location.href = `mailto:info@garuas.com?subject=${encodeURIComponent('Evaluación viabilidad concesión (staging)')}&body=${resumen}`;
+    return false;
+  }
+}
+
+function renderConfirmation(estado) {
+  if (!confirmation || !confirmationMessage) return;
+  const mensaje = estado.admisiblePreliminar
+    ? 'Su solicitud es admisible preliminarmente. En menos de 24 horas recibirá confirmación y la cotización.'
+    : '¡Gracias! En menos de 24 horas le contactaremos para confirmar viabilidad y enviar la cotización. En algunos casos se requiere visita técnica y/o valoración de viabilidad ambiental.';
+  confirmationMessage.textContent = mensaje;
+  confirmation.classList.remove('hidden');
+  form.classList.add('hidden');
+}
+
+function resetForm() {
+  form.reset();
+  state.respuestas = {};
+  Object.keys(followUpsConfig).forEach((question) => {
+    if (followUpsConfig[question]?.container) {
+      toggleContainer(followUpsConfig[question].container, false);
+    }
+  });
+  Object.values(alertBoxes).forEach((box) => box?.classList.add('hidden'));
+  document.querySelectorAll('.option-btn').forEach((btn) => btn.setAttribute('aria-pressed', 'false'));
+  if (marker) {
+    map.removeLayer(marker);
+    marker = null;
+  }
+  latInput.value = '';
+  lngInput.value = '';
+  confirmation.classList.add('hidden');
+  form.classList.remove('hidden');
+  form.empresa.value = '';
+  updateProgress();
+  showMessage('');
+}
+
+form.addEventListener('submit', async (event) => {
+  event.preventDefault();
+  showMessage('');
+
+  if (form.empresa.value.trim() !== '') {
+    console.warn('Honeypot activado.');
+    return;
+  }
+
+  if (!form.reportValidity()) {
+    return;
+  }
+
+  const active = getActiveQuestions();
+  const missing = active.filter((key) => !state.respuestas[key]);
+  if (missing.length) {
+    showMessage('Complete todas las preguntas requeridas para continuar.');
+    return;
+  }
+
+  if (!latInput.value || !lngInput.value) {
+    showMessage('Marque el punto en el mapa para continuar.');
+    return;
+  }
+
+  const payload = getPayload();
+  const estado = payload.estado;
+  await sendPayload(payload);
+  renderConfirmation(estado);
+});
+
+backButton.addEventListener('click', () => {
+  resetForm();
+});
+
+function initMap() {
+  if (!window.L) {
+    setTimeout(initMap, 200);
+    return;
+  }
+  map = L.map('map', { scrollWheelZoom: true, tap: false }).setView([9.936, -84.09], 8);
+  L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+    attribution: '&copy; <a href="https://www.openstreetmap.org/">OpenStreetMap</a> colaboradores',
+  }).addTo(map);
+
+  map.on('click', (event) => {
+    const { lat, lng } = event.latlng;
+    if (!marker) {
+      marker = L.marker([lat, lng]).addTo(map);
+    } else {
+      marker.setLatLng([lat, lng]);
+    }
+    latInput.value = lat.toFixed(6);
+    lngInput.value = lng.toFixed(6);
+    latInput.dispatchEvent(new Event('change'));
+    lngInput.dispatchEvent(new Event('change'));
+  });
+}
+
+window.addEventListener('load', () => {
+  initMap();
+  updateProgress();
+});
+
+showMessage('');

--- a/staging/concesion-superficial/index.html
+++ b/staging/concesion-superficial/index.html
@@ -1,0 +1,388 @@
+<!DOCTYPE html>
+<html lang="es" class="h-full">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Garúa · Evaluación de viabilidad de concesión de agua superficial</title>
+    <meta
+      name="description"
+      content="Evaluación de viabilidad y cotización preliminar para concesión de agua superficial con Garúa."
+    />
+    <meta name="robots" content="noindex,nofollow" />
+    <meta name="googlebot" content="noindex,nofollow" />
+    <!-- X-Robots-Tag header snippet suggestions:
+      Netlify: [[headers]]\n  for = "/staging/concesion-superficial*"\n  [headers.values]\n  X-Robots-Tag = "noindex, nofollow"
+      NGINX: add_header X-Robots-Tag "noindex, nofollow"; (within location /staging/)
+      Apache: Header set X-Robots-Tag "noindex, nofollow" (in <Location "/staging/">)
+    -->
+    <!-- Para reforzar privacidad, bloquee /staging/ en robots.txt si el entorno lo permite. -->
+    <link rel="icon" href="/assets/favicon.svg" />
+    <link
+      rel="stylesheet"
+      href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
+      integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY="
+      crossorigin=""
+    />
+    <script src="https://cdn.tailwindcss.com?plugins=forms"></script>
+    <script>
+      tailwind.config = {
+        theme: {
+          extend: {
+            colors: {
+              primary: {
+                50: '#edf6f9',
+                100: '#d8eef1',
+                500: '#3b9d8f',
+                600: '#2f7c72',
+              },
+            },
+          },
+        },
+      };
+    </script>
+    <style>
+      .option-btn {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        border-radius: 9999px;
+        border: 1px solid rgba(148, 163, 184, 0.6);
+        padding: 0.6rem 1.5rem;
+        font-size: 0.95rem;
+        font-weight: 600;
+        color: rgb(71, 85, 105);
+        background: white;
+        transition: all 0.2s ease;
+        box-shadow: inset 0 0 0 0 rgba(59, 157, 143, 0);
+      }
+      .option-btn:hover,
+      .option-btn:focus-visible {
+        border-color: rgba(59, 157, 143, 0.7);
+        box-shadow: 0 0 0 3px rgba(59, 157, 143, 0.15);
+        outline: none;
+      }
+      .option-btn[aria-pressed='true'] {
+        background: linear-gradient(135deg, #3b9d8f, #2f7c72);
+        color: white;
+        border-color: transparent;
+        box-shadow: inset 0 0 0 0 rgba(59, 157, 143, 0.2);
+      }
+      .option-btn[disabled] {
+        opacity: 0.5;
+        cursor: not-allowed;
+      }
+    </style>
+  </head>
+  <body class="min-h-full bg-slate-50 text-slate-800" data-access-token="8b6a5213-7c50-4967-a0a2-35d26f260841">
+    <div id="restricted" class="min-h-screen flex items-center justify-center p-6">
+      <div class="max-w-md text-center bg-white shadow-lg rounded-2xl p-8">
+        <h1 class="text-2xl font-semibold text-slate-900">Página no disponible</h1>
+        <p class="mt-4 text-slate-600">
+          Necesita un enlace válido para acceder a esta evaluación de viabilidad. Si cree que es un
+          error,
+          contacte a <a class="text-primary-600 font-semibold" href="mailto:info@garuas.com">info@garuas.com</a>.
+        </p>
+      </div>
+    </div>
+    <div id="page" class="hidden">
+      <div class="relative overflow-hidden">
+        <div class="absolute inset-0 pointer-events-none" aria-hidden="true">
+          <div class="absolute -top-10 -right-16 h-48 w-48 rounded-full bg-primary-50"></div>
+          <div class="absolute bottom-0 left-10 h-32 w-32 rounded-full bg-primary-100"></div>
+        </div>
+        <div class="relative mx-auto max-w-6xl px-4 py-10 sm:px-6 lg:px-8">
+          <header class="mb-10">
+            <div class="flex flex-col gap-6 sm:flex-row sm:items-center sm:justify-between">
+              <div class="flex items-center gap-4">
+                <div class="flex h-14 w-14 items-center justify-center rounded-full bg-primary-100">
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 64 64"
+                    class="h-10 w-10 text-primary-600"
+                    aria-hidden="true"
+                  >
+                    <path
+                      fill="currentColor"
+                      d="M33 4c-7.2 9.4-17.4 23-17.4 32.2 0 9.9 7.7 17.8 17.4 17.8s17.4-7.9 17.4-17.8C50.4 27 40.2 13.4 33 4zm0 43.6c-6.1 0-11-5.1-11-11.4 0-3.4 2.3-7.9 6.9-14.4 1.4 2.5 3.5 5.5 6.2 8.7 4.3 5.1 4.9 7.7 4.9 10.1 0 6.3-4.9 11.4-11 11.4z"
+                    />
+                  </svg>
+                  <span class="sr-only">Garúa</span>
+                </div>
+                <div>
+                  <p class="text-sm uppercase tracking-wide text-primary-600">Garúa</p>
+                  <h1 class="text-2xl font-semibold text-slate-900">
+                    Evaluación de viabilidad de concesión de agua superficial
+                  </h1>
+                </div>
+              </div>
+              <p class="rounded-full bg-white/90 px-4 py-2 text-sm font-medium text-primary-600 shadow-sm">
+                Respuesta en &lt; 24 h con viabilidad y cotización preliminar
+              </p>
+            </div>
+          </header>
+          <main class="grid gap-8 lg:grid-cols-[minmax(0,1fr)_360px]">
+            <section>
+              <div class="mb-6">
+                <div class="flex items-center justify-between">
+                  <p class="text-sm font-medium text-slate-600">Progreso</p>
+                  <span id="progress-label" class="text-sm font-semibold text-primary-600">0%</span>
+                </div>
+                <div class="mt-2 h-2 rounded-full bg-slate-200">
+                  <div id="progress-bar" class="h-full w-0 rounded-full bg-primary-500 transition-all"></div>
+                </div>
+              </div>
+              <div
+                id="formMessage"
+                class="hidden rounded-2xl border border-amber-200 bg-amber-50 p-4 text-sm text-amber-700"
+                role="alert"
+                aria-live="assertive"
+              ></div>
+              <form id="preEvalForm" class="space-y-8" novalidate>
+                <input type="text" name="empresa" autocomplete="off" class="hidden" tabindex="-1" aria-hidden="true" />
+                <fieldset class="space-y-6 rounded-2xl bg-white p-6 shadow-sm">
+                  <legend class="text-lg font-semibold text-slate-900">Datos de contacto</legend>
+                  <div>
+                    <label for="nombre" class="block text-sm font-medium text-slate-700">Nombre y apellidos *</label>
+                    <input
+                      id="nombre"
+                      name="nombre"
+                      type="text"
+                      required
+                      autocomplete="name"
+                      class="mt-1 block w-full rounded-xl border-slate-200 bg-slate-50 focus:border-primary-500 focus:ring-primary-500"
+                    />
+                  </div>
+                  <div>
+                    <label for="correo" class="block text-sm font-medium text-slate-700">Correo electrónico *</label>
+                    <input
+                      id="correo"
+                      name="correo"
+                      type="email"
+                      required
+                      autocomplete="email"
+                      class="mt-1 block w-full rounded-xl border-slate-200 bg-slate-50 focus:border-primary-500 focus:ring-primary-500"
+                    />
+                  </div>
+                  <div>
+                    <label for="telefono" class="block text-sm font-medium text-slate-700">Teléfono o WhatsApp *</label>
+                    <input
+                      id="telefono"
+                      name="telefono"
+                      type="tel"
+                      required
+                      autocomplete="tel"
+                      class="mt-1 block w-full rounded-xl border-slate-200 bg-slate-50 focus:border-primary-500 focus:ring-primary-500"
+                    />
+                  </div>
+                </fieldset>
+
+                <fieldset class="space-y-4 rounded-2xl bg-white p-6 shadow-sm">
+                  <legend class="text-lg font-semibold text-slate-900">Ubicación aproximada</legend>
+                  <p class="text-sm text-slate-600">
+                    Haga clic para marcar el punto más aproximado de la naciente. Puede mover el mapa para ubicarla.
+                  </p>
+                  <div class="h-72 overflow-hidden rounded-2xl" id="map" role="region" aria-label="Mapa para ubicar la naciente"></div>
+                  <div class="grid gap-4 sm:grid-cols-2">
+                    <div>
+                      <label for="lat" class="block text-sm font-medium text-slate-700">Latitud *</label>
+                      <input
+                        id="lat"
+                        name="lat"
+                        type="text"
+                        readonly
+                        required
+                        class="mt-1 block w-full rounded-xl border-slate-200 bg-slate-100 focus:border-primary-500 focus:ring-primary-500"
+                      />
+                    </div>
+                    <div>
+                      <label for="lng" class="block text-sm font-medium text-slate-700">Longitud *</label>
+                      <input
+                        id="lng"
+                        name="lng"
+                        type="text"
+                        readonly
+                        required
+                        class="mt-1 block w-full rounded-xl border-slate-200 bg-slate-100 focus:border-primary-500 focus:ring-primary-500"
+                      />
+                    </div>
+                  </div>
+                </fieldset>
+
+                <section class="space-y-6">
+                  <h2 class="text-lg font-semibold text-slate-900">Cuestionario</h2>
+
+                  <div class="space-y-6">
+                    <article class="rounded-2xl bg-white p-6 shadow-sm" data-step="q1">
+                      <h3 class="text-base font-semibold text-slate-900">
+                        ¿Es usted propietario del inmueble o de los inmuebles donde se pretende realizar el aprovechamiento del agua?
+                      </h3>
+                      <div class="mt-4 flex flex-wrap gap-3" role="radiogroup" aria-labelledby="q1-label">
+                        <button type="button" class="option-btn" data-question="q1" data-value="si">Sí</button>
+                        <button type="button" class="option-btn" data-question="q1" data-value="no">No</button>
+                      </div>
+                      <div class="mt-4 hidden space-y-3" data-follow-up="q1">
+                        <p class="text-sm text-slate-600">¿Cuenta con un poder notarial que lo autorice a realizar la solicitud?</p>
+                        <div class="flex flex-wrap gap-3" role="radiogroup">
+                          <button type="button" class="option-btn" data-question="q1b" data-value="si">Sí</button>
+                          <button type="button" class="option-btn" data-question="q1b" data-value="no">No</button>
+                        </div>
+                      </div>
+                    </article>
+
+                    <article class="rounded-2xl bg-white p-6 shadow-sm" data-step="q2">
+                      <h3 class="text-base font-semibold text-slate-900">
+                        ¿La propiedad está inscrita en el Registro Nacional de la Propiedad?
+                      </h3>
+                      <div class="mt-4 flex flex-wrap gap-3" role="radiogroup">
+                        <button type="button" class="option-btn" data-question="q2" data-value="si">Sí</button>
+                        <button type="button" class="option-btn" data-question="q2" data-value="no">No</button>
+                      </div>
+                      <div class="mt-4 hidden space-y-3" data-follow-up="q2">
+                        <p class="text-sm text-slate-600">¿Está en proceso de regularización como información posesoria?</p>
+                        <div class="flex flex-wrap gap-3" role="radiogroup">
+                          <button type="button" class="option-btn" data-question="q2b" data-value="si">Sí</button>
+                          <button type="button" class="option-btn" data-question="q2b" data-value="no">No</button>
+                        </div>
+                      </div>
+                    </article>
+
+                    <article class="rounded-2xl bg-white p-6 shadow-sm" data-step="q3">
+                      <h3 class="text-base font-semibold text-slate-900">¿Está al día con Hacienda, CCSS y la DA?</h3>
+                      <div class="mt-4 flex flex-wrap gap-3" role="radiogroup">
+                        <button type="button" class="option-btn" data-question="q3" data-value="si">Sí</button>
+                        <button type="button" class="option-btn" data-question="q3" data-value="no">No</button>
+                      </div>
+                      <p class="mt-4 hidden rounded-xl border border-amber-200 bg-amber-50 p-3 text-sm text-amber-700" data-alert="q3">
+                        Debe regularizarse ante Hacienda, CCSS y la Dirección de Aguas para avanzar con la concesión.
+                      </p>
+                    </article>
+
+                    <article class="rounded-2xl bg-white p-6 shadow-sm" data-step="q5">
+                      <h3 class="text-base font-semibold text-slate-900">¿La fuente se encuentra dentro de un Parque Nacional?</h3>
+                      <div class="mt-4 flex flex-wrap gap-3" role="radiogroup">
+                        <button type="button" class="option-btn" data-question="q5" data-value="si">Sí</button>
+                        <button type="button" class="option-btn" data-question="q5" data-value="no">No</button>
+                      </div>
+                      <div class="mt-4 hidden space-y-3" data-follow-up="q5">
+                        <p class="text-sm text-slate-600">¿La propiedad solicitante también está dentro del Parque Nacional?</p>
+                        <div class="flex flex-wrap gap-3" role="radiogroup">
+                          <button type="button" class="option-btn" data-question="q5b" data-value="si">Sí</button>
+                          <button type="button" class="option-btn" data-question="q5b" data-value="no">No</button>
+                        </div>
+                      </div>
+                    </article>
+
+                    <article class="rounded-2xl bg-white p-6 shadow-sm" data-step="q6">
+                      <h3 class="text-base font-semibold text-slate-900">
+                        ¿La conducción del agua hasta su propiedad NO atraviesa terrenos de terceros?
+                      </h3>
+                      <div class="mt-4 flex flex-wrap gap-3" role="radiogroup">
+                        <button type="button" class="option-btn" data-question="q6" data-value="si">Sí</button>
+                        <button type="button" class="option-btn" data-question="q6" data-value="no">No</button>
+                      </div>
+                      <div class="mt-4 hidden space-y-3" data-follow-up="q6">
+                        <p class="text-sm text-slate-600">¿Cuenta con autorización de los propietarios involucrados?</p>
+                        <div class="flex flex-wrap gap-3" role="radiogroup">
+                          <button type="button" class="option-btn" data-question="q6b" data-value="si">Sí</button>
+                          <button type="button" class="option-btn" data-question="q6b" data-value="no">No</button>
+                        </div>
+                        <div class="hidden space-y-3" data-follow-up="q6b">
+                          <p class="text-sm text-slate-600">¿Puede conducir por cauce de dominio público (río/quebrada)?</p>
+                          <div class="flex flex-wrap gap-3" role="radiogroup">
+                            <button type="button" class="option-btn" data-question="q6c" data-value="si">Sí</button>
+                            <button type="button" class="option-btn" data-question="q6c" data-value="no">No</button>
+                          </div>
+                        </div>
+                      </div>
+                      <p class="mt-4 hidden rounded-xl border border-amber-200 bg-amber-50 p-3 text-sm text-amber-700" data-alert="q6">
+                        Si requiere servidumbre forzosa o acuerdo privado, podemos asesorarle durante la evaluación.
+                      </p>
+                    </article>
+
+                    <article class="rounded-2xl bg-white p-6 shadow-sm" data-step="q7">
+                      <h3 class="text-base font-semibold text-slate-900">¿El uso es para consumo humano (agua potable)?</h3>
+                      <div class="mt-4 flex flex-wrap gap-3" role="radiogroup">
+                        <button type="button" class="option-btn" data-question="q7" data-value="si">Sí</button>
+                        <button type="button" class="option-btn" data-question="q7" data-value="no">No</button>
+                      </div>
+                      <div class="mt-4 hidden rounded-xl border border-primary-100 bg-primary-50 p-3 text-sm text-primary-700" data-alert="q7">
+                        El uso de agua para consumo humano está restringido a un proveedor estatal. ¿Desea continuar la solicitud para usos adicionales?
+                        <div class="mt-3 flex flex-wrap gap-3">
+                          <button type="button" class="option-btn" data-question="q7b" data-value="si">Sí</button>
+                          <button type="button" class="option-btn" data-question="q7b" data-value="no">No</button>
+                        </div>
+                      </div>
+                    </article>
+
+                    <article class="rounded-2xl bg-white p-6 shadow-sm" data-step="q8">
+                      <h3 class="text-base font-semibold text-slate-900">¿El aprovechamiento se encuentra fuera de áreas de protección?</h3>
+                      <div class="mt-4 flex flex-wrap gap-3" role="radiogroup">
+                        <button type="button" class="option-btn" data-question="q8" data-value="si">Sí</button>
+                        <button type="button" class="option-btn" data-question="q8" data-value="no">No</button>
+                      </div>
+                    </article>
+                  </div>
+                </section>
+
+                <div class="flex flex-col gap-4 rounded-2xl bg-white p-6 shadow-sm">
+                  <button
+                    type="submit"
+                    class="w-full rounded-full bg-primary-600 px-6 py-3 text-base font-semibold text-white shadow-lg transition hover:bg-primary-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-600"
+                  >
+                    Enviar pre-evaluación
+                  </button>
+                  <p class="text-xs text-slate-500">
+                    Su información se usará únicamente para evaluar viabilidad y cotizar. No compartimos datos con terceros.
+                  </p>
+                </div>
+              </form>
+              <div id="confirmation" class="hidden rounded-2xl bg-white p-8 text-center shadow-sm">
+                <h2 class="text-2xl font-semibold text-slate-900">¡Gracias!</h2>
+                <p id="confirmation-message" class="mt-4 text-sm text-slate-600"></p>
+                <button
+                  type="button"
+                  id="backButton"
+                  class="mt-6 inline-flex items-center justify-center rounded-full border border-primary-600 px-5 py-2 text-sm font-semibold text-primary-600 transition hover:bg-primary-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-600"
+                >
+                  Registrar otra solicitud
+                </button>
+              </div>
+            </section>
+
+            <aside class="space-y-6">
+              <div class="rounded-2xl bg-white p-6 shadow-sm">
+                <h2 class="text-lg font-semibold text-slate-900">Ubicación referencial</h2>
+                <p class="mt-2 text-sm text-slate-600">
+                  Ajuste el mapa para que nuestro equipo cuente con un punto de partida en la inspección.
+                </p>
+                <ul class="mt-4 space-y-2 text-sm text-slate-500">
+                  <li>• Puede mover el marcador haciendo clic nuevamente.</li>
+                  <li>• Si necesita asistencia, llámenos o escriba a <a class="text-primary-600 font-semibold" href="mailto:info@garuas.com">info@garuas.com</a>.</li>
+                  <li>• En algunos casos coordinamos visita técnica y valoración ambiental.</li>
+                </ul>
+              </div>
+              <div class="rounded-2xl bg-white p-6 shadow-sm">
+                <h2 class="text-lg font-semibold text-slate-900">Contacto</h2>
+                <p class="mt-2 text-sm text-slate-600">info@garuas.com · +506 0000-0000</p>
+              </div>
+            </aside>
+          </main>
+        </div>
+      </div>
+      <footer class="border-t border-slate-200 bg-white/70">
+        <div class="mx-auto flex max-w-6xl flex-col gap-3 px-4 py-6 text-sm text-slate-500 sm:flex-row sm:items-center sm:justify-between">
+          <p>&copy; <span id="year"></span> Garúa. Todos los derechos reservados.</p>
+          <p>Aviso de privacidad: Su información se usa solo para evaluar viabilidad y cotizar. No compartimos datos con terceros.</p>
+        </div>
+      </footer>
+    </div>
+
+    <script
+      src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
+      integrity="sha256-o9N1j7kP5Uft+RmseQGhX8Ss4i/WZk+3A1X3x0i0XvY="
+      crossorigin=""
+      defer
+    ></script>
+    <script src="/staging/concesion-superficial/app.js" type="module" defer></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a staging-only evaluación de viabilidad landing in `/staging/concesion-superficial/` with Tailwind UI, Leaflet map and conditional questionnaire
- duplicate the page under secret slug `/staging/concesion-superficial-4a83002e/` with token gate, noindex meta tags and privacy guidance
- document access and QA steps in README_STAGING.md

## Testing
- no automated tests were run (static content)

------
https://chatgpt.com/codex/tasks/task_e_68cf0d6883c0832ea4dbc14d83ae902c