### PR TITLE
Retire Bandera Azul webinar listing and mark page as finished

### DIFF
--- a/Cursos/bandera-azul/index.html
+++ b/Cursos/bandera-azul/index.html
@@ -3,11 +3,12 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Webinar Gratis · Cómo obtener la Bandera Azul Ecológica para su empresa | Garúa</title>
-  <meta name="description" content="Aprenda los requisitos y pasos clave para obtener la Bandera Azul Ecológica en su empresa. Webinar gratuito de Garúa con guía descargable y sesión de preguntas." />
-  <meta property="og:title" content="Webinar Gratis · Bandera Azul Ecológica para su empresa" />
-  <meta property="og:description" content="Requisitos y pasos clave para empresas privadas en Costa Rica. Regístrese gratis." />
-  <meta property="og:type" content="event" />
+  <title>Evento finalizado · Cómo obtener la Bandera Azul Ecológica | Garúa</title>
+  <meta name="description" content="Este webinar sobre la Bandera Azul Ecológica finalizó el 24 de septiembre de 2025. Consulte próximos cursos de Garúa." />
+  <meta name="robots" content="noindex, follow" />
+  <meta property="og:title" content="Evento finalizado · Bandera Azul Ecológica para su empresa" />
+  <meta property="og:description" content="El webinar concluyó el 24 de septiembre de 2025. Descubra otros cursos y recursos de Garúa." />
+  <meta property="og:type" content="article" />
   <meta property="og:url" content="https://garuas.com/Cursos/bandera-azul/" />
   <meta property="og:image" content="https://garuas.com/assets/garua_logo_banner2_recortado.png" />
   <meta property="og:locale" content="es_CR" />
@@ -16,23 +17,6 @@
   <link rel="icon" href="/assets/logo.png" />
   <script src="https://cdn.tailwindcss.com"></script>
   <style>html{scroll-behavior:smooth}</style>
-  <script type="application/ld+json">
-  {
-    "@context": "https://schema.org",
-    "@type": "Event",
-    "name": "Webinar: Cómo obtener la Bandera Azul Ecológica para su empresa",
-    "startDate": "2025-09-24T18:00:00-06:00",
-    "endDate": "2025-09-24T19:00:00-06:00",
-    "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
-    "eventStatus": "https://schema.org/EventScheduled",
-    "description": "Requisitos y pasos clave para que empresas privadas en Costa Rica obtengan el reconocimiento Bandera Azul Ecológica.",
-    "image": ["https://garuas.com/assets/garua_logo_banner2_recortado.png"],
-    "location": {"@type":"VirtualLocation","url":"https://meet.google.com/"},
-    "organizer": {"@type":"Organization","name":"Garúa","url":"https://garuas.com"},
-    "inLanguage":"es-CR",
-    "isAccessibleForFree": true
-  }
-  </script>
 </head>
 <body class="min-h-screen bg-white text-slate-800">
   <header class="w-full border-b bg-white/80 backdrop-blur">
@@ -51,134 +35,80 @@
         <a href="/" class="hover:text-sky-700">Inicio</a>
         <a href="/#servicios" class="hover:text-sky-700">Servicios</a>
         <a href="/Cursos/" class="text-sky-700 font-medium">Cursos</a>
-        <a href="#registro" class="rounded-lg px-3 py-1.5 bg-sky-600 text-white hover:bg-sky-700">Registrarme</a>
       </nav>
     </div>
   <nav id="mobile-menu" class="md:hidden hidden flex flex-col gap-4 border-t px-4 pb-4 text-sm bg-white">
     <a href="/" class="hover:text-sky-700">Inicio</a>
     <a href="/#servicios" class="hover:text-sky-700">Servicios</a>
     <a href="/Cursos/" class="hover:text-sky-700">Cursos</a>
-    <a href="#registro" class="hover:text-sky-700">Registrarme</a>
   </nav>
   </header>
 
-  <section class="w-full bg-gradient-to-br from-sky-50 to-white">
-    <div class="mx-auto max-w-6xl px-4 py-12 grid lg:grid-cols-2 gap-10 items-center">
-      <div>
-        <h1 class="text-3xl md:text-4xl font-bold leading-tight">Cómo obtener la <span class="text-sky-700">Bandera Azul Ecológica</span> para su empresa</h1>
-        <p class="mt-4 text-lg text-slate-600">Requisitos y pasos clave para empresas privadas en Costa Rica. Webinar gratuito con ejemplos prácticos, checklist descargable y espacio de preguntas.</p>
+  <section class="w-full border-b bg-white">
+    <div class="mx-auto max-w-3xl px-4 py-16 text-center">
+      <div class="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-slate-50 px-4 py-1 text-xs font-semibold uppercase tracking-wide text-slate-600">
+        Finalizado
+      </div>
+      <h1 class="mt-6 text-3xl md:text-4xl font-bold">Evento finalizado</h1>
+      <p class="mt-4 text-lg text-slate-600">Este webinar se realizó el miércoles 24 de septiembre de 2025 (GMT-6).</p>
+      <div class="mt-6 flex flex-wrap items-center justify-center gap-3">
+        <a href="/Cursos/" class="inline-flex items-center justify-center rounded-xl bg-sky-600 px-5 py-3 text-white font-semibold shadow-sm hover:bg-sky-700">Ver próximos cursos</a>
+      </div>
+    </div>
+  </section>
+
+  <section class="mx-auto max-w-4xl px-4 py-12">
+    <h2 class="text-2xl font-bold">Resumen del evento</h2>
+    <p class="mt-2 text-slate-600">Reviva los temas que cubrimos en el webinar “Cómo obtener la Bandera Azul Ecológica para su empresa”.</p>
+    <div class="mt-8 space-y-6">
+      <details class="rounded-2xl border bg-white p-6 shadow-sm">
+        <summary class="cursor-pointer text-lg font-semibold text-slate-800">Información general</summary>
         <ul class="mt-4 space-y-2 text-slate-700">
           <li>• Fecha: <strong>Miércoles 24 de septiembre de 2025</strong></li>
           <li>• Hora: <strong>6:00–7:00 p. m. (GMT-6)</strong></li>
-          <li>• Modalidad: <strong>En línea (Zoom/Meet)</strong></li>
+          <li>• Modalidad: <strong>En línea</strong></li>
         </ul>
-        <div class="mt-6 flex flex-wrap items-center gap-3">
-          <a href="#registro" class="inline-flex items-center rounded-xl bg-sky-600 px-5 py-3 text-white font-semibold hover:bg-sky-700">Registrarme gratis</a>
-          <a href="#temario" class="inline-flex items-center rounded-xl px-5 py-3 border border-slate-300 hover:bg-slate-50">Ver temario</a>
-        </div>
-        <div class="mt-6 p-4 border rounded-xl bg-white/70">
-          <p class="font-medium text-slate-700">Comienza en:</p>
-          <div id="countdown" class="mt-2 text-2xl font-semibold tracking-wider">–d : –h : –m : –s</div>
-        </div>
-      </div>
-      <div class="relative">
-        <div class="rounded-2xl border shadow-sm p-6 bg-white">
-          <h3 class="text-xl font-semibold">Lo que aprenderá</h3>
-          <ul class="mt-3 space-y-2 text-slate-700">
-            <li>✔ Requisitos y evidencias que solicita el Programa.</li>
-            <li>✔ Pasos para organizar el proyecto y cronograma anual.</li>
-            <li>✔ Errores comunes que retrasan la certificación.</li>
-            <li>✔ Beneficios reales y cómo comunicarlos.</li>
-          </ul>
-          <p class="mt-4 text-sm text-slate-500">Incluye: checklist descargable y certificado de participación (digital).</p>
-        </div>
-      </div>
-    </div>
-  </section>
-
-  <section id="temario" class="mx-auto max-w-6xl px-4 py-12">
-    <h2 class="text-2xl font-bold">Temario</h2>
-    <div class="mt-6 grid md:grid-cols-2 gap-6">
-      <div class="rounded-2xl border p-6">
-        <h3 class="font-semibold">1) Introducción</h3>
-        <p class="mt-2 text-slate-700">Qué es la Bandera Azul Ecológica, categorías aplicables a empresas y por qué es estratégica.</p>
-      </div>
-      <div class="rounded-2xl border p-6">
-        <h3 class="font-semibold">2) Requisitos clave</h3>
-        <p class="mt-2 text-slate-700">Documentación, registros, plazos y evidencias típicas que solicita el comité local.</p>
-      </div>
-      <div class="rounded-2xl border p-6">
-        <h3 class="font-semibold">3) Pasos para obtenerla</h3>
-        <p class="mt-2 text-slate-700">Diagnóstico, plan de acción, implementación, presentación y seguimiento.</p>
-      </div>
-      <div class="rounded-2xl border p-6">
-        <h3 class="font-semibold">4) Casos y errores comunes</h3>
-        <p class="mt-2 text-slate-700">Buenas prácticas y fallas frecuentes que frenan el proceso.</p>
-      </div>
-    </div>
-  </section>
-
-  <section id="registro" class="w-full bg-slate-50 border-y">
-    <div class="mx-auto max-w-6xl px-4 py-12 grid lg:grid-cols-2 gap-10 items-start">
-      <div>
-        <h2 class="text-2xl font-bold">Regístrese gratis</h2>
-        <p class="mt-2 text-slate-700">Complete el formulario para recibir el enlace del evento y el material descargable.</p>
-        <form action="https://formspree.io/f/xpwlbowj" method="POST" class="mt-6 space-y-4 rounded-2xl border bg-white p-6 shadow-sm">
-          <input type="hidden" name="_subject" value="Registro webinar Bandera Azul · Garúa" />
-          <div>
-            <label for="nombre" class="block text-sm font-medium">Nombre y apellidos</label>
-            <input id="nombre" required name="nombre" class="mt-1 w-full rounded-lg border px-3 py-2" placeholder="Nombre completo" />
+        <p class="mt-4 text-sm text-slate-500">Los enlaces de registro ya no están activos.</p>
+      </details>
+      <details class="rounded-2xl border bg-white p-6 shadow-sm">
+        <summary class="cursor-pointer text-lg font-semibold text-slate-800">Lo que se abordó</summary>
+        <ul class="mt-4 space-y-2 text-slate-700">
+          <li>✔ Requisitos y evidencias que solicita el Programa.</li>
+          <li>✔ Pasos para organizar el proyecto y cronograma anual.</li>
+          <li>✔ Errores comunes que retrasan la certificación.</li>
+          <li>✔ Beneficios reales y cómo comunicarlos.</li>
+        </ul>
+      </details>
+      <details class="rounded-2xl border bg-white p-6 shadow-sm">
+        <summary class="cursor-pointer text-lg font-semibold text-slate-800">Temario del webinar</summary>
+        <div class="mt-4 grid md:grid-cols-2 gap-4 text-slate-700">
+          <div class="rounded-2xl border p-4">
+            <h3 class="font-semibold">1) Introducción</h3>
+            <p class="mt-2 text-slate-700">Qué es la Bandera Azul Ecológica, categorías aplicables a empresas y por qué es estratégica.</p>
           </div>
-          <div>
-            <label for="email" class="block text-sm font-medium">Correo electrónico</label>
-            <input id="email" required type="email" name="email" class="mt-1 w-full rounded-lg border px-3 py-2" placeholder="correo@empresa.com" />
+          <div class="rounded-2xl border p-4">
+            <h3 class="font-semibold">2) Requisitos clave</h3>
+            <p class="mt-2 text-slate-700">Documentación, registros, plazos y evidencias típicas que solicita el comité local.</p>
           </div>
-          <div>
-            <label for="empresa" class="block text-sm font-medium">Empresa</label>
-            <input id="empresa" name="empresa" class="mt-1 w-full rounded-lg border px-3 py-2" placeholder="Nombre de la empresa (opcional)" />
+          <div class="rounded-2xl border p-4">
+            <h3 class="font-semibold">3) Pasos para obtenerla</h3>
+            <p class="mt-2 text-slate-700">Diagnóstico, plan de acción, implementación, presentación y seguimiento.</p>
           </div>
-          <div>
-            <label for="sector" class="block text-sm font-medium">Sector</label>
-            <select id="sector" name="sector" class="mt-1 w-full rounded-lg border px-3 py-2">
-              <option>Industrial</option>
-              <option>Servicios</option>
-              <option>Turismo/Hotelero</option>
-              <option>Agrícola</option>
-              <option>Otro</option>
-            </select>
+          <div class="rounded-2xl border p-4">
+            <h3 class="font-semibold">4) Casos y errores comunes</h3>
+            <p class="mt-2 text-slate-700">Buenas prácticas y fallas frecuentes que frenan el proceso.</p>
           </div>
-          <div class="flex items-center gap-2 text-sm">
-            <input id="acepto" type="checkbox" required class="h-4 w-4" />
-            <label for="acepto">Acepto recibir comunicaciones sobre este evento y materiales relacionados.</label>
-          </div>
-          <button class="w-full rounded-xl bg-sky-600 px-5 py-3 text-white font-semibold hover:bg-sky-700">Enviar registro</button>
-          <p class="text-xs text-slate-500">Protegemos sus datos. Solo los usaremos para comunicaciones del webinar y seguimiento.</p>
-        </form>
-      </div>
-      <aside class="space-y-6">
-        <div class="rounded-2xl border bg-white p-6 shadow-sm">
-          <h3 class="font-semibold">Ponente</h3>
-          <p class="mt-2 text-slate-700">Equipo de Garúa (operación de PTAR, consultoría ambiental y salud ocupacional). Experiencia en implementación de sistemas de gestión, cumplimiento y capacitación empresarial.</p>
         </div>
-        <div class="rounded-2xl border bg-white p-6 shadow-sm">
-          <h3 class="font-semibold">Incluye</h3>
-          <ul class="mt-2 space-y-2 text-slate-700">
-            <li>• Grabación disponible por 7 días.</li>
-            <li>• Checklist “Pasos para Bandera Azul en mi empresa”.</li>
-            <li>• Certificado de participación (digital).</li>
-          </ul>
-        </div>
-      </aside>
-    </div>
-  </section>
-
-  <section class="mx-auto max-w-6xl px-4 py-12">
-    <div class="rounded-2xl bg-gradient-to-br from-sky-600 to-sky-700 p-8 text-white flex flex-col md:flex-row items-center justify-between gap-6">
-      <div>
-        <h3 class="text-2xl font-bold">Lleve a su empresa al siguiente nivel</h3>
-        <p class="mt-2 text-sky-100">Aprenda los pasos clave para obtener la Bandera Azul Ecológica con una guía clara y práctica.</p>
-      </div>
-      <a href="#registro" class="rounded-xl bg-white/10 px-6 py-3 font-semibold backdrop-blur hover:bg-white/20">Registrarme</a>
+      </details>
+      <details class="rounded-2xl border bg-white p-6 shadow-sm">
+        <summary class="cursor-pointer text-lg font-semibold text-slate-800">Ponente y materiales</summary>
+        <p class="mt-4 text-slate-700">Equipo de Garúa (operación de PTAR, consultoría ambiental y salud ocupacional). Experiencia en implementación de sistemas de gestión, cumplimiento y capacitación empresarial.</p>
+        <ul class="mt-4 space-y-2 text-slate-700">
+          <li>• Grabación disponible por 7 días.</li>
+          <li>• Checklist “Pasos para Bandera Azul en mi empresa”.</li>
+          <li>• Certificado de participación (digital).</li>
+        </ul>
+      </details>
     </div>
   </section>
 
@@ -211,18 +141,6 @@
   </script>
   <script>
     document.getElementById('y').textContent = new Date().getFullYear();
-    const eventDate = new Date('2025-09-24T18:00:00-06:00').getTime();
-    const el = document.getElementById('countdown');
-    const timer = setInterval(() => {
-      const now = new Date().getTime();
-      const d = Math.max(eventDate - now, 0);
-      const days = Math.floor(d / (1000*60*60*24));
-      const hours = Math.floor((d % (1000*60*60*24))/(1000*60*60));
-      const mins = Math.floor((d % (1000*60*60))/(1000*60));
-      const secs = Math.floor((d % (1000*60))/1000);
-      el.textContent = `${days}d : ${hours}h : ${mins}m : ${secs}s`;
-      if (d === 0) clearInterval(timer);
-    }, 1000);
   </script>
 </body>
 </html>

--- a/Cursos/index.html
+++ b/Cursos/index.html
@@ -46,12 +46,9 @@
     <h1 class="text-3xl md:text-4xl font-bold">Cursos y Eventos</h1>
     <p class="mt-4 text-lg text-slate-600">Capacitaciones y webinars de Garúa sobre agua, ambiente y salud ocupacional.</p>
 
-    <div class="mt-8 grid md:grid-cols-2 gap-6">
-      <article class="rounded-xl border p-6 bg-white">
-        <h2 class="text-xl font-semibold">Webinar: Bandera Azul Ecológica para su empresa</h2>
-        <p class="mt-2 text-slate-700">Requisitos y pasos clave para empresas privadas en Costa Rica.</p>
-        <a href="/Cursos/bandera-azul/" class="mt-4 inline-flex items-center text-sky-700 hover:underline">Ver detalles →</a>
-      </article>
+    <div class="mt-8 rounded-xl border border-dashed bg-white p-8 text-center text-slate-600">
+      <p class="text-lg font-medium text-slate-700">Pronto publicaremos nuevos cursos y webinars.</p>
+      <p class="mt-2">Mientras tanto, explore nuestros servicios o contáctenos para capacitación a la medida.</p>
     </div>
   </main>
 

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -19,12 +19,6 @@
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://garuas.com/Cursos/bandera-azul/</loc>
-    <lastmod>2025-08-21</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
-  </url>
-  <url>
     <loc>https://garuas.com/operacion-ptar-costa-rica/</loc>
     <lastmod>2025-08-21</lastmod>
     <changefreq>monthly</changefreq>


### PR DESCRIPTION
## Summary
- mark the Bandera Azul webinar page as finished with an updated hero, finalizado badge, and webinar recap details
- remove registration CTAs and event schema data while setting the page to noindex
- hide the Bandera Azul webinar from course listings and the sitemap entry

## Testing
- not run (static site changes)


------
https://chatgpt.com/codex/tasks/task_e_68d497f9b128832eb14ee0fc64e6f9b4