### PR TITLE
Add public Garúa Aforos privacy policy page with embedded PDF viewer

### DIFF
--- a/privacy-aforos/index.html
+++ b/privacy-aforos/index.html
@@ -1,0 +1,135 @@
+<!doctype html>
+<html lang="es">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="robots" content="noindex,nofollow" />
+  <title>Política de Privacidad – Garúa Aforos</title>
+  <style>
+    :root {
+      --bg: #f7f9fc;
+      --card: #ffffff;
+      --text: #1f2933;
+      --muted: #5f6c7b;
+      --brand: #163d60;
+      --brand-soft: #e8eef5;
+      --border: #d8e0ea;
+    }
+
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      font-family: Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Arial, sans-serif;
+      color: var(--text);
+      background: linear-gradient(180deg, #f8fbff 0%, var(--bg) 100%);
+      min-height: 100vh;
+    }
+
+    .container {
+      width: min(1080px, 92vw);
+      margin: 0 auto;
+      padding: 2.25rem 0 2.5rem;
+    }
+
+    .header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      flex-wrap: wrap;
+      gap: 0.75rem;
+      margin-bottom: 1.15rem;
+    }
+
+    h1 {
+      margin: 0;
+      font-size: clamp(1.3rem, 2.4vw, 1.9rem);
+      font-weight: 650;
+      letter-spacing: 0.01em;
+      color: var(--brand);
+    }
+
+    .download {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.45rem;
+      border: 1px solid var(--border);
+      background: var(--card);
+      color: var(--brand);
+      text-decoration: none;
+      padding: 0.56rem 0.85rem;
+      border-radius: 0.65rem;
+      font-size: 0.93rem;
+      font-weight: 560;
+      transition: all .2s ease;
+    }
+
+    .download:hover,
+    .download:focus-visible {
+      border-color: #b7c7d8;
+      background: var(--brand-soft);
+      outline: none;
+    }
+
+    .subtitle {
+      margin: 0 0 1rem;
+      color: var(--muted);
+      font-size: 0.95rem;
+    }
+
+    .viewer-shell {
+      background: var(--card);
+      border: 1px solid var(--border);
+      border-radius: 0.95rem;
+      overflow: hidden;
+      box-shadow: 0 10px 32px rgba(18, 43, 66, 0.08);
+    }
+
+    iframe {
+      width: 100%;
+      border: 0;
+      height: 78vh;
+      min-height: 520px;
+      background: #f0f4f9;
+    }
+
+    .fallback {
+      padding: 1rem;
+      font-size: 0.95rem;
+      color: var(--muted);
+      border-top: 1px solid var(--border);
+      background: #fbfdff;
+    }
+
+    @media (max-width: 720px) {
+      .container { padding-top: 1.3rem; }
+      iframe {
+        height: 72vh;
+        min-height: 440px;
+      }
+    }
+  </style>
+</head>
+<body>
+  <main class="container" aria-label="Política de Privacidad Garúa Aforos">
+    <div class="header">
+      <h1>Política de Privacidad – Garúa Aforos</h1>
+      <a class="download" href="./politica-privacidad-garua-aforos.pdf" download>
+        Descargar PDF
+      </a>
+    </div>
+
+    <p class="subtitle">Documento legal oficial para Google Play Console.</p>
+
+    <section class="viewer-shell" aria-label="Visor de política de privacidad">
+      <iframe
+        title="Política de Privacidad – Garúa Aforos"
+        src="./politica-privacidad-garua-aforos.pdf#view=FitH"
+        loading="lazy">
+      </iframe>
+      <div class="fallback">
+        Si tu navegador no muestra el visor PDF, puedes descargar el archivo con el botón superior.
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/privacy-aforos/politica-privacidad-garua-aforos.pdf
+++ b/privacy-aforos/politica-privacidad-garua-aforos.pdf
@@ -1,0 +1,266 @@
+%PDF-1.4
+%
+1 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+2 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica-Bold >>
+endobj
+3 0 obj
+<< /Length 3523 >>
+stream
+BT
+0.06 0.17 0.28 rg
+/F2 20 Tf
+1 0 0 1 60 780 Tm
+(Poltica de Privacidad ? Gara Aforos) Tj
+0.35 0.40 0.46 rg
+/F1 11 Tf
+1 0 0 1 60 756 Tm
+(ltima actualizacin: 17 de mayo de 2026) Tj
+0.12 0.16 0.20 rg
+/F1 11 Tf
+1 0 0 1 60 732 Tm
+(Gara Aforos es una aplicacin desarrollada por Gara con el objetivo de) Tj
+0.12 0.16 0.20 rg
+/F1 11 Tf
+1 0 0 1 60 715 Tm
+(realizar estimaciones de velocidad superficial y caudal en cauces abiertos) Tj
+0.12 0.16 0.20 rg
+/F1 11 Tf
+1 0 0 1 60 698 Tm
+(mediante anlisis de video.) Tj
+0.12 0.16 0.20 rg
+/F1 11 Tf
+1 0 0 1 60 677 Tm
+(La presente Poltica de Privacidad describe cmo la aplicacin maneja la) Tj
+0.12 0.16 0.20 rg
+/F1 11 Tf
+1 0 0 1 60 660 Tm
+(informacin utilizada durante su funcionamiento.) Tj
+0.12 0.16 0.20 rg
+/F1 11 Tf
+1 0 0 1 60 639 Tm
+(1. Informacin utilizada por la aplicacin) Tj
+0.12 0.16 0.20 rg
+/F1 11 Tf
+1 0 0 1 60 618 Tm
+(La aplicacin puede acceder a:) Tj
+0.12 0.16 0.20 rg
+/F1 11 Tf
+1 0 0 1 60 597 Tm
+(? Videos seleccionados manualmente por el usuario desde el dispositivo.) Tj
+0.12 0.16 0.20 rg
+/F1 11 Tf
+1 0 0 1 60 576 Tm
+(? Informacin bsica necesaria para el funcionamiento de la aplicacin y) Tj
+0.12 0.16 0.20 rg
+/F1 11 Tf
+1 0 0 1 60 559 Tm
+(el procesamiento local de los anlisis.) Tj
+0.12 0.16 0.20 rg
+/F1 11 Tf
+1 0 0 1 60 538 Tm
+(Gara Aforos no recopila informacin personal sensible del usuario de forma) Tj
+0.12 0.16 0.20 rg
+/F1 11 Tf
+1 0 0 1 60 521 Tm
+(intencional.) Tj
+0.12 0.16 0.20 rg
+/F1 11 Tf
+1 0 0 1 60 500 Tm
+(2. Procesamiento de videos) Tj
+0.12 0.16 0.20 rg
+/F1 11 Tf
+1 0 0 1 60 479 Tm
+(Los videos utilizados para el anlisis son seleccionados directamente por el) Tj
+0.12 0.16 0.20 rg
+/F1 11 Tf
+1 0 0 1 60 462 Tm
+(usuario.) Tj
+0.12 0.16 0.20 rg
+/F1 11 Tf
+1 0 0 1 60 441 Tm
+(El procesamiento de los videos se realiza localmente en el dispositivo del) Tj
+0.12 0.16 0.20 rg
+/F1 11 Tf
+1 0 0 1 60 424 Tm
+(usuario para efectuar clculos relacionados con:) Tj
+0.12 0.16 0.20 rg
+/F1 11 Tf
+1 0 0 1 60 403 Tm
+(? velocidad superficial,) Tj
+0.12 0.16 0.20 rg
+/F1 11 Tf
+1 0 0 1 60 382 Tm
+(? seguimiento visual de partculas,) Tj
+0.12 0.16 0.20 rg
+/F1 11 Tf
+1 0 0 1 60 361 Tm
+(? estimacin hidrulica de caudal,) Tj
+0.12 0.16 0.20 rg
+/F1 11 Tf
+1 0 0 1 60 340 Tm
+(? anlisis tcnico de flujo.) Tj
+0.12 0.16 0.20 rg
+/F1 11 Tf
+1 0 0 1 60 319 Tm
+(La aplicacin no transmite automticamente los videos analizados a servidores) Tj
+0.12 0.16 0.20 rg
+/F1 11 Tf
+1 0 0 1 60 302 Tm
+(externos durante el proceso de anlisis normal.) Tj
+0.12 0.16 0.20 rg
+/F1 11 Tf
+1 0 0 1 60 281 Tm
+(3. Almacenamiento de informacin) Tj
+0.12 0.16 0.20 rg
+/F1 11 Tf
+1 0 0 1 60 260 Tm
+(La aplicacin puede almacenar temporalmente informacin asociada a anlisis) Tj
+0.12 0.16 0.20 rg
+/F1 11 Tf
+1 0 0 1 60 243 Tm
+(realizados localmente en el dispositivo con fines operativos y de funcionamiento) Tj
+0.12 0.16 0.20 rg
+/F1 11 Tf
+1 0 0 1 60 226 Tm
+(interno.) Tj
+0.12 0.16 0.20 rg
+/F1 11 Tf
+1 0 0 1 60 205 Tm
+(El usuario mantiene el control sobre los archivos seleccionados desde su) Tj
+0.12 0.16 0.20 rg
+/F1 11 Tf
+1 0 0 1 60 188 Tm
+(dispositivo.) Tj
+0.12 0.16 0.20 rg
+/F1 11 Tf
+1 0 0 1 60 167 Tm
+(4. Comparticin de informacin) Tj
+0.12 0.16 0.20 rg
+/F1 11 Tf
+1 0 0 1 60 146 Tm
+(Gara Aforos no vende ni comercializa informacin personal de los usuarios.) Tj
+0.12 0.16 0.20 rg
+/F1 11 Tf
+1 0 0 1 60 125 Tm
+(La aplicacin no comparte automticamente videos ni archivos seleccionados con) Tj
+0.12 0.16 0.20 rg
+/F1 11 Tf
+1 0 0 1 60 108 Tm
+(terceros durante el uso normal de la aplicacin.) Tj
+ET
+endstream
+endobj
+4 0 obj
+<< /Length 1840 >>
+stream
+BT
+0.12 0.16 0.20 rg
+/F1 11 Tf
+1 0 0 1 60 780 Tm
+(5. Permisos utilizados) Tj
+0.12 0.16 0.20 rg
+/F1 11 Tf
+1 0 0 1 60 759 Tm
+(La aplicacin puede solicitar permisos relacionados con:) Tj
+0.12 0.16 0.20 rg
+/F1 11 Tf
+1 0 0 1 60 738 Tm
+(? acceso a archivos multimedia o videos,) Tj
+0.12 0.16 0.20 rg
+/F1 11 Tf
+1 0 0 1 60 717 Tm
+(? lectura de contenido seleccionado por el usuario,) Tj
+0.12 0.16 0.20 rg
+/F1 11 Tf
+1 0 0 1 60 696 Tm
+(? almacenamiento temporal requerido para el procesamiento local.) Tj
+0.12 0.16 0.20 rg
+/F1 11 Tf
+1 0 0 1 60 675 Tm
+(Estos permisos se utilizan exclusivamente para el funcionamiento tcnico de la) Tj
+0.12 0.16 0.20 rg
+/F1 11 Tf
+1 0 0 1 60 658 Tm
+(aplicacin.) Tj
+0.12 0.16 0.20 rg
+/F1 11 Tf
+1 0 0 1 60 637 Tm
+(6. Uso tcnico y limitaciones) Tj
+0.12 0.16 0.20 rg
+/F1 11 Tf
+1 0 0 1 60 616 Tm
+(Los resultados generados por Gara Aforos corresponden a estimaciones tcnicas) Tj
+0.12 0.16 0.20 rg
+/F1 11 Tf
+1 0 0 1 60 599 Tm
+(basadas en procesamiento de imgenes y parmetros ingresados por el usuario.) Tj
+0.12 0.16 0.20 rg
+/F1 11 Tf
+1 0 0 1 60 578 Tm
+(La aplicacin no sustituye mediciones hidrulicas oficiales ni criterios) Tj
+0.12 0.16 0.20 rg
+/F1 11 Tf
+1 0 0 1 60 561 Tm
+(tcnicos profesionales especializados.) Tj
+0.12 0.16 0.20 rg
+/F1 11 Tf
+1 0 0 1 60 540 Tm
+(7. Cambios en esta poltica) Tj
+0.12 0.16 0.20 rg
+/F1 11 Tf
+1 0 0 1 60 519 Tm
+(Gara podr actualizar esta Poltica de Privacidad cuando resulte necesario para) Tj
+0.12 0.16 0.20 rg
+/F1 11 Tf
+1 0 0 1 60 502 Tm
+(mejorar la aplicacin o cumplir requisitos tcnicos, legales o regulatorios.) Tj
+0.12 0.16 0.20 rg
+/F1 11 Tf
+1 0 0 1 60 481 Tm
+(8. Contacto) Tj
+0.12 0.16 0.20 rg
+/F1 11 Tf
+1 0 0 1 60 460 Tm
+(Gara) Tj
+0.12 0.16 0.20 rg
+/F1 11 Tf
+1 0 0 1 60 439 Tm
+(info@garuas.com) Tj
+0.12 0.16 0.20 rg
+/F1 11 Tf
+1 0 0 1 60 418 Tm
+(https://garuas.com) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Page /Parent 7 0 R /MediaBox [0 0 595 842] /Resources << /Font << /F1 1 0 R /F2 2 0 R >> >> /Contents 3 0 R >>
+endobj
+6 0 obj
+<< /Type /Page /Parent 7 0 R /MediaBox [0 0 595 842] /Resources << /Font << /F1 1 0 R /F2 2 0 R >> >> /Contents 4 0 R >>
+endobj
+7 0 obj
+<< /Type /Pages /Kids [5 0 R 6 0 R] /Count 2 >>
+endobj
+8 0 obj
+<< /Type /Catalog /Pages 7 0 R >>
+endobj
+xref
+0 9
+0000000000 65535 f 
+0000000015 00000 n 
+0000000085 00000 n 
+0000000160 00000 n 
+0000003735 00000 n 
+0000005627 00000 n 
+0000005763 00000 n 
+0000005899 00000 n 
+0000005962 00000 n 
+trailer
+<< /Size 9 /Root 8 0 R >>
+startxref
+6011
+%%EOF


### PR DESCRIPTION
### Motivation

- Proveer una página pública en `https://garuas.com/privacy-aforos` con la Política de Privacidad requerida por Google Play Console, accesible sin login y sin aparecer en la navegación principal.
- Mostrar el documento legal directamente en la página mediante un visor PDF integrado y ofrecer descarga discreta, reduciendo indexación con `noindex,nofollow`.

### Description

- Añade el archivo `privacy-aforos/index.html` que incluye `<meta name="robots" content="noindex,nofollow">`, estilos minimalistas y un visor PDF responsive embebido mediante `iframe` junto a un botón `Descargar PDF`.
- Genera y añade el PDF estático `privacy-aforos/politica-privacidad-garua-aforos.pdf` que se carga dentro del `iframe` y está disponible para descarga.
- No se modificaron otras páginas ni la navegación del sitio; la solución es ligera y compatible con GitHub Pages (sin dependencias externas).

### Testing

- Ejecuté un script Python que verificó la existencia de `privacy-aforos/politica-privacidad-garua-aforos.pdf` y `privacy-aforos/index.html`, comprobó el encabezado PDF (`%PDF-1.4`) y confirmó la presencia de `noindex,nofollow` y del `iframe` en el HTML, y ese chequeo pasó correctamente.
- El commit que añade ambos archivos se creó correctamente (`git commit` pasó). 
- Algunos comandos auxiliares fallaron por limitaciones del entorno: la comprobación con `file` no funcionó porque `file` no está instalado, y un intento de `python -m py_compile` falló por un comando mal formado en el agente; estos fallos son del entorno, no del contenido añadido.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a6aaacbfc832e81323fc5f7b008ea)