### PR TITLE
Add Spanish privacy policy page and PDF for Garúa Aforos

### DIFF
--- a/privacy-aforos/index.html
+++ b/privacy-aforos/index.html
@@ -1,0 +1,135 @@
+<!doctype html>
+<html lang="es">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="robots" content="noindex,nofollow" />
+  <title>Política de Privacidad – Garúa Aforos</title>
+  <style>
+    :root {
+      --bg: #f7f9fc;
+      --card: #ffffff;
+      --text: #1f2933;
+      --muted: #5f6c7b;
+      --brand: #163d60;
+      --brand-soft: #e8eef5;
+      --border: #d8e0ea;
+    }
+
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      font-family: Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Arial, sans-serif;
+      color: var(--text);
+      background: linear-gradient(180deg, #f8fbff 0%, var(--bg) 100%);
+      min-height: 100vh;
+    }
+
+    .container {
+      width: min(1080px, 92vw);
+      margin: 0 auto;
+      padding: 2.25rem 0 2.5rem;
+    }
+
+    .header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      flex-wrap: wrap;
+      gap: 0.75rem;
+      margin-bottom: 1.15rem;
+    }
+
+    h1 {
+      margin: 0;
+      font-size: clamp(1.3rem, 2.4vw, 1.9rem);
+      font-weight: 650;
+      letter-spacing: 0.01em;
+      color: var(--brand);
+    }
+
+    .download {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.45rem;
+      border: 1px solid var(--border);
+      background: var(--card);
+      color: var(--brand);
+      text-decoration: none;
+      padding: 0.56rem 0.85rem;
+      border-radius: 0.65rem;
+      font-size: 0.93rem;
+      font-weight: 560;
+      transition: all .2s ease;
+    }
+
+    .download:hover,
+    .download:focus-visible {
+      border-color: #b7c7d8;
+      background: var(--brand-soft);
+      outline: none;
+    }
+
+    .subtitle {
+      margin: 0 0 1rem;
+      color: var(--muted);
+      font-size: 0.95rem;
+    }
+
+    .viewer-shell {
+      background: var(--card);
+      border: 1px solid var(--border);
+      border-radius: 0.95rem;
+      overflow: hidden;
+      box-shadow: 0 10px 32px rgba(18, 43, 66, 0.08);
+    }
+
+    iframe {
+      width: 100%;
+      border: 0;
+      height: 78vh;
+      min-height: 520px;
+      background: #f0f4f9;
+    }
+
+    .fallback {
+      padding: 1rem;
+      font-size: 0.95rem;
+      color: var(--muted);
+      border-top: 1px solid var(--border);
+      background: #fbfdff;
+    }
+
+    @media (max-width: 720px) {
+      .container { padding-top: 1.3rem; }
+      iframe {
+        height: 72vh;
+        min-height: 440px;
+      }
+    }
+  </style>
+</head>
+<body>
+  <main class="container" aria-label="Política de Privacidad Garúa Aforos">
+    <div class="header">
+      <h1>Política de Privacidad – Garúa Aforos</h1>
+      <a class="download" href="./politica-privacidad-garua-aforos.pdf" download>
+        Descargar PDF
+      </a>
+    </div>
+
+    <p class="subtitle">Documento legal oficial para Google Play Console.</p>
+
+    <section class="viewer-shell" aria-label="Visor de política de privacidad">
+      <iframe
+        title="Política de Privacidad – Garúa Aforos"
+        src="./politica-privacidad-garua-aforos.pdf#view=FitH"
+        loading="lazy">
+      </iframe>
+      <div class="fallback">
+        Si tu navegador no muestra el visor PDF, puedes descargar el archivo con el botón superior.
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/privacy-aforos/politica-privacidad-garua-aforos.pdf
+++ b/privacy-aforos/politica-privacidad-garua-aforos.pdf
@@ -1,0 +1,246 @@
+%PDF-1.4
+%
+1 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica /Encoding /WinAnsiEncoding >>
+endobj
+2 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding >>
+endobj
+3 0 obj
+<< /Length 3852 >>
+stream
+BT
+0.07 0.17 0.28 rg
+/F2 18 Tf
+1 0 0 1 56 790 Tm
+(Poltica de Privacidad ? Gara Aforos) Tj
+0.35 0.40 0.46 rg
+/F1 11 Tf
+1 0 0 1 56 775 Tm
+(ltima actualizacin: 17 de mayo de 2026) Tj
+0.12 0.16 0.20 rg
+/F1 10.8 Tf
+1 0 0 1 56 752 Tm
+(Gara Aforos es una aplicacin desarrollada por Gara con el objetivo de realizar) Tj
+0.12 0.16 0.20 rg
+/F1 10.8 Tf
+1 0 0 1 56 737 Tm
+(estimaciones de velocidad superficial y caudal en cauces abiertos mediante anlisis de) Tj
+0.12 0.16 0.20 rg
+/F1 10.8 Tf
+1 0 0 1 56 722 Tm
+(video.) Tj
+0.12 0.16 0.20 rg
+/F1 10.8 Tf
+1 0 0 1 56 699 Tm
+(La presente Poltica de Privacidad describe cmo la aplicacin maneja la informacin) Tj
+0.12 0.16 0.20 rg
+/F1 10.8 Tf
+1 0 0 1 56 684 Tm
+(utilizada durante su funcionamiento.) Tj
+0.09 0.24 0.38 rg
+/F2 12 Tf
+1 0 0 1 56 661 Tm
+(1. Informacin utilizada por la aplicacin) Tj
+0.12 0.16 0.20 rg
+/F1 10.8 Tf
+1 0 0 1 56 638 Tm
+(La aplicacin puede acceder a:) Tj
+0.12 0.16 0.20 rg
+/F1 10.8 Tf
+1 0 0 1 56 615 Tm
+(Videos seleccionados manualmente por el usuario desde el dispositivo.) Tj
+0.12 0.16 0.20 rg
+/F1 10.8 Tf
+1 0 0 1 56 600 Tm
+(Informacin bsica necesaria para el funcionamiento de la aplicacin y el procesamiento) Tj
+0.12 0.16 0.20 rg
+/F1 10.8 Tf
+1 0 0 1 56 585 Tm
+(local de los anlisis.) Tj
+0.12 0.16 0.20 rg
+/F1 10.8 Tf
+1 0 0 1 56 562 Tm
+(Gara Aforos no recopila informacin personal sensible del usuario de forma intencional.) Tj
+0.09 0.24 0.38 rg
+/F2 12 Tf
+1 0 0 1 56 539 Tm
+(2. Procesamiento de videos) Tj
+0.12 0.16 0.20 rg
+/F1 10.8 Tf
+1 0 0 1 56 516 Tm
+(Los videos utilizados para el anlisis son seleccionados directamente por el usuario.) Tj
+0.12 0.16 0.20 rg
+/F1 10.8 Tf
+1 0 0 1 56 493 Tm
+(El procesamiento de los videos se realiza localmente en el dispositivo del usuario para) Tj
+0.12 0.16 0.20 rg
+/F1 10.8 Tf
+1 0 0 1 56 478 Tm
+(efectuar clculos relacionados con:) Tj
+0.12 0.16 0.20 rg
+/F1 10.8 Tf
+1 0 0 1 56 455 Tm
+(velocidad superficial,) Tj
+0.12 0.16 0.20 rg
+/F1 10.8 Tf
+1 0 0 1 56 440 Tm
+(seguimiento visual de partculas,) Tj
+0.12 0.16 0.20 rg
+/F1 10.8 Tf
+1 0 0 1 56 425 Tm
+(estimacin hidrulica de caudal,) Tj
+0.12 0.16 0.20 rg
+/F1 10.8 Tf
+1 0 0 1 56 410 Tm
+(anlisis tcnico de flujo.) Tj
+0.12 0.16 0.20 rg
+/F1 10.8 Tf
+1 0 0 1 56 387 Tm
+(La aplicacin no transmite automticamente los videos analizados a servidores externos) Tj
+0.12 0.16 0.20 rg
+/F1 10.8 Tf
+1 0 0 1 56 372 Tm
+(durante el proceso de anlisis normal.) Tj
+0.09 0.24 0.38 rg
+/F2 12 Tf
+1 0 0 1 56 349 Tm
+(3. Almacenamiento de informacin) Tj
+0.12 0.16 0.20 rg
+/F1 10.8 Tf
+1 0 0 1 56 326 Tm
+(La aplicacin puede almacenar temporalmente informacin asociada a anlisis realizados) Tj
+0.12 0.16 0.20 rg
+/F1 10.8 Tf
+1 0 0 1 56 311 Tm
+(localmente en el dispositivo con fines operativos y de funcionamiento interno.) Tj
+0.12 0.16 0.20 rg
+/F1 10.8 Tf
+1 0 0 1 56 288 Tm
+(El usuario mantiene el control sobre los archivos seleccionados desde su dispositivo.) Tj
+0.09 0.24 0.38 rg
+/F2 12 Tf
+1 0 0 1 56 265 Tm
+(4. Comparticin de informacin) Tj
+0.12 0.16 0.20 rg
+/F1 10.8 Tf
+1 0 0 1 56 242 Tm
+(Gara Aforos no vende ni comercializa informacin personal de los usuarios.) Tj
+0.12 0.16 0.20 rg
+/F1 10.8 Tf
+1 0 0 1 56 219 Tm
+(La aplicacin no comparte automticamente videos ni archivos seleccionados con terceros) Tj
+0.12 0.16 0.20 rg
+/F1 10.8 Tf
+1 0 0 1 56 204 Tm
+(durante el uso normal de la aplicacin.) Tj
+0.09 0.24 0.38 rg
+/F2 12 Tf
+1 0 0 1 56 181 Tm
+(5. Permisos utilizados) Tj
+0.12 0.16 0.20 rg
+/F1 10.8 Tf
+1 0 0 1 56 158 Tm
+(La aplicacin puede solicitar permisos relacionados con:) Tj
+0.12 0.16 0.20 rg
+/F1 10.8 Tf
+1 0 0 1 56 135 Tm
+(acceso a archivos multimedia o videos,) Tj
+0.12 0.16 0.20 rg
+/F1 10.8 Tf
+1 0 0 1 56 120 Tm
+(lectura de contenido seleccionado por el usuario,) Tj
+0.12 0.16 0.20 rg
+/F1 10.8 Tf
+1 0 0 1 56 105 Tm
+(almacenamiento temporal requerido para el procesamiento local.) Tj
+ET
+endstream
+endobj
+4 0 obj
+<< /Length 1316 >>
+stream
+BT
+0.12 0.16 0.20 rg
+/F1 10.8 Tf
+1 0 0 1 56 790 Tm
+(Estos permisos se utilizan exclusivamente para el funcionamiento tcnico de la aplicacin.) Tj
+0.09 0.24 0.38 rg
+/F2 12 Tf
+1 0 0 1 56 767 Tm
+(6. Uso tcnico y limitaciones) Tj
+0.12 0.16 0.20 rg
+/F1 10.8 Tf
+1 0 0 1 56 744 Tm
+(Los resultados generados por Gara Aforos corresponden a estimaciones tcnicas basadas en) Tj
+0.12 0.16 0.20 rg
+/F1 10.8 Tf
+1 0 0 1 56 729 Tm
+(procesamiento de imgenes y parmetros ingresados por el usuario.) Tj
+0.12 0.16 0.20 rg
+/F1 10.8 Tf
+1 0 0 1 56 706 Tm
+(La aplicacin no sustituye mediciones hidrulicas oficiales ni criterios tcnicos) Tj
+0.12 0.16 0.20 rg
+/F1 10.8 Tf
+1 0 0 1 56 691 Tm
+(profesionales especializados.) Tj
+0.09 0.24 0.38 rg
+/F2 12 Tf
+1 0 0 1 56 668 Tm
+(7. Cambios en esta poltica) Tj
+0.12 0.16 0.20 rg
+/F1 10.8 Tf
+1 0 0 1 56 645 Tm
+(Gara podr actualizar esta Poltica de Privacidad cuando resulte necesario para mejorar la) Tj
+0.12 0.16 0.20 rg
+/F1 10.8 Tf
+1 0 0 1 56 630 Tm
+(aplicacin o cumplir requisitos tcnicos, legales o regulatorios.) Tj
+0.09 0.24 0.38 rg
+/F2 12 Tf
+1 0 0 1 56 607 Tm
+(8. Contacto) Tj
+0.12 0.16 0.20 rg
+/F1 10.8 Tf
+1 0 0 1 56 584 Tm
+(Gara) Tj
+0.12 0.16 0.20 rg
+/F1 10.8 Tf
+1 0 0 1 56 569 Tm
+(info@garuas.com) Tj
+0.12 0.16 0.20 rg
+/F1 10.8 Tf
+1 0 0 1 56 554 Tm
+(https://garuas.com) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Page /Parent 7 0 R /MediaBox [0 0 595 842] /Resources << /Font << /F1 1 0 R /F2 2 0 R >> >> /Contents 3 0 R >>
+endobj
+6 0 obj
+<< /Type /Page /Parent 7 0 R /MediaBox [0 0 595 842] /Resources << /Font << /F1 1 0 R /F2 2 0 R >> >> /Contents 4 0 R >>
+endobj
+7 0 obj
+<< /Type /Pages /Kids [5 0 R 6 0 R] /Count 2 >>
+endobj
+8 0 obj
+<< /Type /Catalog /Pages 7 0 R >>
+endobj
+xref
+0 9
+0000000000 65535 f 
+0000000015 00000 n 
+0000000112 00000 n 
+0000000214 00000 n 
+0000004118 00000 n 
+0000005486 00000 n 
+0000005622 00000 n 
+0000005758 00000 n 
+0000005821 00000 n 
+trailer
+<< /Size 9 /Root 8 0 R >>
+startxref
+5870
+%%EOF


### PR DESCRIPTION
### Motivation
- Provide an official Spanish privacy policy for the Garúa Aforos app suitable for Google Play Console distribution. 
- Make the policy available as a downloadable PDF and an in-browser viewer while preventing indexing with `robots: noindex,nofollow`.

### Description
- Add a new `privacy-aforos` folder containing `privacy-aforos/index.html` which embeds the privacy policy PDF in an accessible iframe and offers a `Download PDF` link. 
- Implement responsive, self-contained styling and accessibility attributes (`aria-label`, `title`) in `index.html`, and include a `meta` tag to prevent search engine indexing. 
- Add the policy document `privacy-aforos/politica-privacidad-garua-aforos.pdf` containing the Spanish privacy policy text formatted for a two-page PDF viewer.

### Testing
- No automated tests were executed for this static content change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a6aaacbfc832e81323fc5f7b008ea)