### PR TITLE
Actualizar enlace y visor al PDF Politica_Privacidad

### DIFF
--- a/privacy-aforos/index.html
+++ b/privacy-aforos/index.html
@@ -113,7 +113,7 @@
   <main class="container" aria-label="Política de Privacidad Garúa Aforos">
     <div class="header">
       <h1>Política de Privacidad – Garúa Aforos</h1>
-      <a class="download" href="./politica-privacidad-garua-aforos.pdf" download>
+      <a class="download" href="./Politica_Privacidad.pdf" download>
         Descargar PDF
       </a>
     </div>
@@ -123,7 +123,7 @@
     <section class="viewer-shell" aria-label="Visor de política de privacidad">
       <iframe
         title="Política de Privacidad – Garúa Aforos"
-        src="./politica-privacidad-garua-aforos.pdf#view=FitH"
+        src="./Politica_Privacidad.pdf#view=FitH"
         loading="lazy">
       </iframe>
       <div class="fallback">


### PR DESCRIPTION
### Motivation
- El visor y el enlace de descarga estaban apuntando al archivo previo `politica-privacidad-garua-aforos.pdf` y se necesita que abran `privacy-aforos/Politica_Privacidad.pdf` en su lugar.

### Description
- Se modificó `privacy-aforos/index.html` para cambiar el `href` del botón de descarga a `./Politica_Privacidad.pdf` y el `src` del `iframe` embebido a `./Politica_Privacidad.pdf#view=FitH`.

### Testing
- Se localizó el PDF objetivo con `rg` y se verificó su existencia en `privacy-aforos/Politica_Privacidad.pdf` (comando `rg` ejecutado correctamente). 
- Se aplicó el cambio mediante un script Python y se validó el resultado con `git diff -- privacy-aforos/index.html` seguido de `git commit`, todos los comandos completaron con éxito.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a70cb9ca4832e9c10135a81093d20)