### PR TITLE
Actualiza política de privacidad de Garúa Aforos (OpenCV e Internet)

### DIFF
--- a/privacy-aforos/index.html
+++ b/privacy-aforos/index.html
@@ -132,9 +132,9 @@
   <main>
     <header>
       <h1>Política de Privacidad — Garúa Aforos</h1>
-      <p class="date">Última actualización: 12 de junio de 2026</p>
+      <p class="date">Última actualización: 10 de julio de 2026</p>
       <p>Garúa Aforos es una aplicación móvil desarrollada por Garúa para apoyar estimaciones técnicas de caudal en campo mediante dos métodos: aforo con video y aforo volumétrico con cronómetro. Esta Política de Privacidad explica cómo la aplicación accede, procesa, almacena y protege la información utilizada durante su funcionamiento.</p>
-      <a class="download" href="./Politica_Privacidad_Garua_Aforos_2026-06-12.pdf" download>Descargar PDF</a>
+      <a class="download" href="./Politica_Privacidad_Garua_Aforos_2026-07-10.pdf" download>Descargar PDF</a>
     </header>
 
     <section>
@@ -216,7 +216,7 @@
 
     <section>
       <h2>8. Uso de internet y enlaces externos</h2>
-      <p>Garúa Aforos no utiliza internet para transmitir datos del usuario, subir videos, enviar reportes ni cargar motores de análisis externos.</p>
+      <p>La aplicación no solicita permiso de acceso a Internet y funciona 100% sin conexión. Por diseño, es técnicamente incapaz de transmitir datos a servidores o terceros. Todo el procesamiento ocurre en el dispositivo.</p>
       <p>La aplicación puede mostrar enlaces informativos, como la política de privacidad, el sitio web de Garúa o información de licencias de software. Cuando el usuario abre uno de estos enlaces, se utiliza el navegador web del sistema o una aplicación externa compatible.</p>
       <p>La navegación en esos sitios externos queda sujeta a las políticas de privacidad de dichos sitios o servicios.</p>
     </section>
@@ -259,8 +259,7 @@
 
     <section>
       <h2>14. Servicios y bibliotecas de terceros</h2>
-      <p>Garúa Aforos puede utilizar OpenCV, una biblioteca de visión por computadora de código abierto distribuida bajo la Licencia Apache 2.0, para apoyar funciones locales de procesamiento visual cuando esté incluida en la versión instalada de la aplicación.</p>
-      <p>La aplicación no utiliza OpenCV ni otras bibliotecas para transmitir datos personales a terceros.</p>
+      <p>El análisis de velocidad se realiza con un motor de procesamiento propio, desarrollado de forma independiente y ejecutado íntegramente en el dispositivo. La aplicación no integra bibliotecas de terceros que recopilen o transmitan datos, ni SDKs de analítica, publicidad o rastreo.</p>
       <p>Garúa Aforos no integra SDKs de analítica, publicidad, redes sociales ni rastreo de usuarios.</p>
     </section>
 


### PR DESCRIPTION
Actualiza la Política de Privacidad publicada en `/privacy-aforos/` para reflejar los cambios de la app Android.

## Cambios en `privacy-aforos/index.html`

- **Sección 14 (Servicios y bibliotecas de terceros):** se elimina la mención a OpenCV y se reemplaza por un texto que describe un motor de procesamiento propio, ejecutado íntegramente en el dispositivo, sin bibliotecas de terceros ni SDKs de analítica, publicidad o rastreo.
- **Sección 8 (Uso de internet y enlaces externos):** se aclara que la aplicación no solicita permiso de acceso a Internet, funciona 100% sin conexión y es técnicamente incapaz de transmitir datos.
- **Fecha de última actualización:** 12 de junio de 2026 → 10 de julio de 2026.
- **Botón de descarga:** ahora apunta a `Politica_Privacidad_Garua_Aforos_2026-07-10.pdf`.

## PDF

El PDF `Politica_Privacidad_Garua_Aforos_2026-07-10.pdf` (subido por separado a `main`) reemplaza al anterior. Se verificó que su contenido incluye los mismos dos cambios y la fecha actualizada. El PDF viejo (`...2026-06-12.pdf`) y la versión desactualizada de mayo (`politica-privacidad-garua-aforos.pdf`) fueron eliminados.

El resto del documento (recopilación de datos, permisos de cámara/galería, reportes locales, contacto info@garuas.com, etc.) no se modificó.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AyHWabdQ7Hz1d53vL6K23P

---
_Generated by [Claude Code](https://claude.ai/code/session_01AyHWabdQ7Hz1d53vL6K23P)_